### PR TITLE
[WIP] Test if chainer does not use deprecated APIs

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ cd chainer
 flake8
 python setup.py build -j 4 develop install --user || python setup.py develop install --user
 
-export PYTHONWARNINGS="ignore::FutureWarning"
+export PYTHONWARNINGS="error::DeprecationWarning,ignore::FutureWarning"
 
 if [ $CUDNN = none ]; then
   nosetests --processes=4 --process-timeout=10000 --stop --with-coverage --cover-branches --cover-package=chainer,cupy -a '!cudnn,!slow'

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -5,7 +5,7 @@ cd chainer
 flake8
 python setup.py develop install --user
 
-export PYTHONWARNINGS="ignore::FutureWarning"
+export PYTHONWARNINGS="error::DeprecationWarning,ignore::FutureWarning"
 nosetests --processes=4 --process-timeout=10000 -a '!gpu,!slow' --stop --with-coverage --cover-branches --cover-package=chainer tests/chainer_tests
 
 coverage xml -i

--- a/test_example.sh
+++ b/test_example.sh
@@ -14,6 +14,7 @@ python -m pip install olefile --user
 python -m pip install --global-option="build_ext" --global-option="--disable-jpeg" pillow --user
 
 run="coverage run -a --branch"
+export PYTHONWARNINGS="error::DeprecationWarning,ignore::FutureWarning"
 
 # mnist
 echo "Running mnist example"


### PR DESCRIPTION
We need to remove deprecation warnings from chainer implementation. And, if we need to test these methods, we need to ignore these warnings.

Chainer uses deprecated APIs now. We need to fix Chainer first.