### PR TITLE
Fix chainer install test

### DIFF
--- a/test_install.sh
+++ b/test_install.sh
@@ -2,9 +2,4 @@
 
 timeout 20m pip install -vvvv chainer/dist/*.tar.gz --user
 
-# check if cupy is installed
-if [ -z "$CUDNN_VER" ]; then
-  python -c 'import cupy'
-else
-  python -c 'import cupy.cuda.cudnn; print(cupy.cuda.cudnn.getVersion())'
-fi
+python -c 'import chainer'


### PR DESCRIPTION
From v2 Chainer doesn't install CuPy. In this test, we only need to `import chainer`