### PR TITLE
Check if the example sciprt exists for previous version of chainer

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -25,8 +25,10 @@ echo "Running mnist example"
 # change epoch
 $run examples/mnist/train_mnist.py --epoch=1 --unit=10
 $run examples/mnist/train_mnist.py --gpu=0 --epoch=1 --unit=10
-$run examples/mnist/train_mnist_custom_loop.py --epoch=1 --unit=10
-$run examples/mnist/train_mnist_custom_loop.py --gpu=0 --epoch=1 --unit=10
+if [ -f examples/mnist/train_mnist_custom_loop.py ]; then
+  $run examples/mnist/train_mnist_custom_loop.py --epoch=1 --unit=10
+  $run examples/mnist/train_mnist_custom_loop.py --gpu=0 --epoch=1 --unit=10
+fi
 $run examples/mnist/train_mnist_model_parallel.py --gpu0=0 --gpu1=1 --epoch=1 --unit=10
 $run examples/mnist/train_mnist_data_parallel.py --gpu0=0 --gpu1=1 --epoch=1 --unit=10
 


### PR DESCRIPTION
In chainer v2, `train_mnist_custom_loop.py` does not exit. And it causes an error. I fixed the test script to skip this test in v2.