### PR TITLE
Simplify Chainer install test

### DIFF
--- a/run_install_test.py
+++ b/run_install_test.py
@@ -10,10 +10,8 @@ import shuffle
 
 params = {
     'base': docker.base_choices,
-    'cuda_cudnn': docker.get_cuda_cudnn_choices('chainer', with_dummy=True),
-    'nccl': docker.nccl_choices,
     'numpy': ['1.9', '1.10', '1.11', '1.12'],
-    'cython': [None, '0.20', '0.21', '0.22', '0.23', '0.24', '0.25', '0.26'],
+    'setuptools': [None, '3.3', '18.2', '18.3.2'],
     'pip': [None, '7', '8', '9'],
 }
 


### PR DESCRIPTION
Chainer does not depend cuda, cuDNN, NCCL and Cython.