### PR TITLE
Fix cupy install test

### DIFF
--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -17,7 +17,7 @@ params = {
     'cudnn': docker.cudnn_choices + ['cudnn-latest-with-dummy'],
     'nccl': docker.nccl_choices,
     'numpy': ['1.9', '1.10', '1.11', '1.12'],
-    'cython': [None, '0.20', '0.21', '0.23', '0.24'],
+    'cython': [None, '0.21', '0.24', '0.25'],
     'setuptools': [None, '3.3', '18.2', '18.3.2'],
     'pip': [None, '7', '8', '9'],
 }


### PR DESCRIPTION
Cython v0.23 causes install error in specified combination.
