### PR TITLE
Coveralls dependency

### DIFF
--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -46,6 +46,7 @@ if __name__ == '__main__':
         'nose',
         'mock',
         'coverage',
+        'coveralls',
     ]
 
     volume = []

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -45,6 +45,7 @@ if __name__ == '__main__':
         'nose',
         'mock',
         'coverage',
+        'coveralls',
     ]
 
     volume = []

--- a/run_multi_test.py
+++ b/run_multi_test.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
         'nose',
         'mock',
         'coverage',
+        'coveralls',
     ]
 
     if args.cache:


### PR DESCRIPTION
Now `coveralls` is required for all tests using `run_test.py`.