### PR TITLE
Default value for --gpu-id option

### DIFF
--- a/argconfig.py
+++ b/argconfig.py
@@ -5,6 +5,10 @@ import os
 
 def setup_argument_parser(parser):
     parser.add_argument(
+        '--gpu-id', type=int,
+        help='GPU ID you want to use mainly in the script.
+        use EXECUTOR_NUMBER environment variable by default.')
+    parser.add_argument(
         '--cache',
         help='cache directory to store cupy cache and ccache. '
         'use CHAINER_TEST_CACHE environment variable by default.')
@@ -54,6 +58,10 @@ def get_arg_value(args, arg_key, env_key=None):
 
 
 def parse_args(args, env, conf, volume):
+    gpu_id = get_arg_value(args, 'gpu_id', 'EXECUTOR_NUMBER')
+    if gpu_id is not None:
+        args.gpu_id = int(gpu_id)
+
     cache = get_arg_value(args, 'cache')
     if cache is not None:
         volume.append(cache)

--- a/argconfig.py
+++ b/argconfig.py
@@ -6,8 +6,8 @@ import os
 def setup_argument_parser(parser):
     parser.add_argument(
         '--gpu-id', type=int,
-        help='GPU ID you want to use mainly in the script.
-        use EXECUTOR_NUMBER environment variable by default.')
+        help='GPU ID you want to use mainly in the script.'
+        'use EXECUTOR_NUMBER environment variable by default.')
     parser.add_argument(
         '--cache',
         help='cache directory to store cupy cache and ccache. '

--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -29,9 +29,6 @@ if __name__ == '__main__':
     parser.add_argument('--id', type=int, required=True)
     parser.add_argument('--no-cache', action='store_true')
     parser.add_argument('--timeout', default='1h')
-    parser.add_argument(
-        '--gpu-id', type=int,
-        help='GPU ID you want to use mainly in the script.')
     parser.add_argument('--interactive', action='store_true')
     argconfig.setup_argument_parser(parser)
     args = parser.parse_args()

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -28,9 +28,6 @@ if __name__ == '__main__':
     parser.add_argument('--id', type=int, required=True)
     parser.add_argument('--no-cache', action='store_true')
     parser.add_argument('--timeout', default='1h')
-    parser.add_argument(
-        '--gpu-id', type=int,
-        help='GPU ID you want to use mainly in the script.')
     parser.add_argument('--interactive', action='store_true')
     argconfig.setup_argument_parser(parser)
     args = parser.parse_args()

--- a/run_test.py
+++ b/run_test.py
@@ -17,9 +17,6 @@ if __name__ == '__main__':
     ], required=True)
     parser.add_argument('--no-cache', action='store_true')
     parser.add_argument('--timeout', default='1h')
-    parser.add_argument(
-        '--gpu-id', type=int,
-        help='GPU ID you want to use mainly in the script.')
     parser.add_argument('-i', '--interactive', action='store_true')
     argconfig.setup_argument_parser(parser)
     args = parser.parse_args()


### PR DESCRIPTION
I set default value of --gpu-id option EXECUTOR_NUMBER that is an environment variable for Jenkins. It can simplify jenkins configuration.