### PR TITLE
Stop building protobuf C++ code on CentOS 6

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -30,6 +30,9 @@ def get_shuffle_params(params, index):
        ('ubuntu16' in ret['base'] and ret['cuda'] != 'cuda80'):
         ret['nccl'] = 'none'
 
+    if 'centos6' in ret['base'] and ret.get('protobuf') == 'cpp-3':
+        ret['protobuf'] = '3'
+
     return ret
 
 


### PR DESCRIPTION
Latest protobuf cannot be built with GCC 4.4.