### PR TITLE
Update pip

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
             'cuda': 'cuda80',
             'cudnn': 'cudnn5',
             'nccl': 'none',
-            'requires': ['setuptools', 'cython==0.26', 'numpy<1.12'],
+            'requires': ['setuptools', 'pip', 'cython==0.26', 'numpy<1.12'],
         }
         script = './test_prev_example.sh'
 


### PR DESCRIPTION
prev-example test fails  after some libraries are updated. With this patch, the error will disappear.