### PR TITLE
Test numpy 1.13 for cupy v2

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -59,6 +59,15 @@ def get_cuda_cudnn_choices(target, with_dummy=False):
     return choices
 
 
+def get_numpy_choices():
+    choices = ['1.9', '1.10', '1.11', '1.12'],
+    cupy_version = version.get_cupy_version()
+    if cupy_version is not None and cupy_version[0] >= 2:
+        # cupy v2
+        choices.append('1.13')
+    return choices
+
+
 codes = {}
 
 # base

--- a/docker.py
+++ b/docker.py
@@ -60,7 +60,7 @@ def get_cuda_cudnn_choices(target, with_dummy=False):
 
 
 def get_numpy_choices():
-    choices = ['1.9', '1.10', '1.11', '1.12'],
+    choices = ['1.9', '1.10', '1.11', '1.12']
     cupy_version = version.get_cupy_version()
     if cupy_version is not None and cupy_version[0] >= 2:
         # cupy v2

--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python2
 
 import argparse
-import os
-import random
 
 import argconfig
 import docker
@@ -13,7 +11,7 @@ params = {
     'base': docker.base_choices,
     'cuda_cudnn': docker.get_cuda_cudnn_choices('chainer'),
     'nccl': docker.nccl_choices,
-    'numpy': ['1.9', '1.10', '1.11', '1.12'],
+    'numpy': docker.get_numpy_choices(),
     'scipy': [None, '0.18'],
     'protobuf': ['2', '3', 'cpp-3'],
     'h5py': [None, '2.5', '2.6', '2.7'],

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -13,7 +13,7 @@ params = {
     'base': docker.base_choices,
     'cuda_cudnn': docker.get_cuda_cudnn_choices('cupy'),
     'nccl': docker.nccl_choices,
-    'numpy': ['1.9', '1.10', '1.11', '1.12'],
+    'numpy': docker.get_numpy_choices(),
     'scipy': [None, '0.18'],
 }
 


### PR DESCRIPTION
I added numpy 1.13 to combination tests only for cupy v2. #282 does not check cupy version. it will be closed.