### PR TITLE
Add rm option to docker to remove container after a job is done

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -500,6 +500,7 @@ def run_with(conf, script, no_cache=False, volume=None, env=None,
     signal.signal(signal.SIGTERM, make_handler(run_name))
     signal.signal(signal.SIGINT, make_handler(run_name))
     cmd = ['nvidia-docker', 'run',
+           '--rm',
            '--name=%s' % run_name,
            '-v', '%s:%s' % (host_cwd, work_dir),
            '-w', work_dir,


### PR DESCRIPTION
I added `--rm` option to docker run to remove a container after it is done.