### PR TITLE
Fixed PYTHONWARNINGS environment variable to check warnings

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ cd ..
 cd chainer
 python setup.py install --user
 
-export PYTHONWARNINGS="ignore::FutureWarning"
+export PYTHONWARNINGS="ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:inspect"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then

--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -3,7 +3,7 @@
 cd cupy
 python setup.py build -j 4 develop install --user || python setup.py develop install --user
 
-export PYTHONWARNINGS="ignore::FutureWarning"
+export PYTHONWARNINGS="ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:inspect"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then


### PR DESCRIPTION
We must replace all deprecation warnings. This fix checks if chainer/cupy contain deprecation warnings.
merge this first: https://github.com/chainer/chainer/pull/3363