### PR TITLE
Set CUPY_BUILD_USE_CCACHE

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -219,6 +219,7 @@ RUN curl -L -s -o ccache.tar.gz https://github.com/ccache/ccache/archive/v3.3.4.
     ln -s /usr/bin/ccache g++ && \\
     ln -s /usr/bin/ccache nvcc && \\
     cd / && rm -rf /opt/ccache
+ENV CUPY_BUILD_USE_CCACHE 1
 '''
 
 # cuda


### PR DESCRIPTION
CuPy needs CUPY_BUILD_USE_CCACHE to use ccache for nvcc.