### PR TITLE
Disable multi-process parallel testing

### DIFF
--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -7,4 +7,4 @@ python setup.py develop install --user
 export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
-nosetests --processes=4 --process-timeout=10000 -a '!gpu,!slow' --with-coverage --cover-branches --cover-package=chainer tests/chainer_tests
+nosetests -a '!gpu,!slow' --with-coverage --cover-branches --cover-package=chainer tests/chainer_tests


### PR DESCRIPTION
As pointed out in https://github.com/chainer/chainer-test/pull/315#issuecomment-330204874