### PR TITLE
Do not stop on error

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,9 +10,9 @@ python setup.py install --user
 export PYTHONWARNINGS="ignore::FutureWarning"
 
 if [ $CUDNN = none ]; then
-  nosetests --stop --with-coverage --cover-branches --cover-package=chainer -a '!cudnn,!slow' tests
+  nosetests --with-coverage --cover-branches --cover-package=chainer -a '!cudnn,!slow' tests
 else
-  nosetests --stop --with-coverage --cover-branches --cover-package=chainer -a '!slow' tests
+  nosetests --with-coverage --cover-branches --cover-package=chainer -a '!slow' tests
 fi
 
 python ../push_coveralls.py

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -5,4 +5,4 @@ cd chainer
 python setup.py develop install --user
 
 export PYTHONWARNINGS="ignore::FutureWarning"
-nosetests --processes=4 --process-timeout=10000 -a '!gpu,!slow' --stop --with-coverage --cover-branches --cover-package=chainer tests/chainer_tests
+nosetests --processes=4 --process-timeout=10000 -a '!gpu,!slow' --with-coverage --cover-branches --cover-package=chainer tests/chainer_tests

--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -6,9 +6,9 @@ python setup.py build -j 4 develop install --user || python setup.py develop ins
 export PYTHONWARNINGS="ignore::FutureWarning"
 
 if [ $CUDNN = none ]; then
-  nosetests --stop --with-coverage --cover-branches --cover-package=cupy -a '!cudnn,!slow' tests
+  nosetests --with-coverage --cover-branches --cover-package=cupy -a '!cudnn,!slow' tests
 else
-  nosetests --stop --with-coverage --cover-branches --cover-package=cupy -a '!slow' tests
+  nosetests --with-coverage --cover-branches --cover-package=cupy -a '!slow' tests
 fi
 
 python ../push_coveralls.py


### PR DESCRIPTION
I suggest removing `--stop`.
It makes the test reveal only single error at once, therefore occasionally we need to repeat fix-and-test cycle several times. It takes more computational resource and slows down development process.

Additionally, it's more problematic in the current situation that non-deterministic failure could happen in some tests.