### PR TITLE
Install chainer before cupy

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+# Chainer setup script installs specific version of CuPy.
+# We need to install Chainer first for test.
 cd chainer
 python setup.py install --user
 cd ..

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,14 @@
 #!/bin/sh -ex
 
+cd chainer
+python setup.py install --user
+cd ..
+
 cd cupy
 python setup.py build -j 4 develop install --user || python setup.py develop install --user
 cd ..
 
 cd chainer
-python setup.py install --user
 
 export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1


### PR DESCRIPTION
Chainer setup script tries to install specific version of CuPy even when latest CuPy is installed. To avoid it, I changed installation order.