### PR TITLE
Persist JIT cache to make tests run faster

### DIFF
--- a/argconfig.py
+++ b/argconfig.py
@@ -65,6 +65,7 @@ def parse_args(args, env, conf, volume):
     cache = get_arg_value(args, 'cache')
     if cache is not None:
         volume.append(cache)
+        env['CUDA_CACHE_PATH'] = os.path.join(args.cache, '.nv')
         env['CUPY_CACHE_DIR'] = os.path.join(cache, '.cupy')
         env['CCACHE_DIR'] = os.path.join(cache, '.ccache')
 

--- a/argconfig.py
+++ b/argconfig.py
@@ -65,7 +65,7 @@ def parse_args(args, env, conf, volume):
     cache = get_arg_value(args, 'cache')
     if cache is not None:
         volume.append(cache)
-        env['CUDA_CACHE_PATH'] = os.path.join(args.cache, '.nv')
+        env['CUDA_CACHE_PATH'] = os.path.join(cache, '.nv')
         env['CUPY_CACHE_DIR'] = os.path.join(cache, '.cupy')
         env['CCACHE_DIR'] = os.path.join(cache, '.ccache')
 

--- a/run_multi_test.py
+++ b/run_multi_test.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
 
     if args.cache:
         volume.append(args.cache)
+        env['CUDA_CACHE_PATH'] = os.path.join(args.cache, '.nv')
         env['CUPY_CACHE_DIR'] = os.path.join(args.cache, '.cupy')
         env['CCACHE_DIR'] = os.path.join(args.cache, '.ccache')
 


### PR DESCRIPTION
Store JIT cache files in the specified directory to make tests run faster.

Without JIT cache:

```
$ time ./run_test.py --test chainer-py2 --cache /tmp/my-cache
1.65s user 3.58s system 1% cpu 6:52.21 total
```

With JIT cache (once JIT cache is generated):

```
$ time ./run_test.py --test chainer-py2 --cache /tmp/my-cache
1.73s user 2.92s system 1% cpu 4:43.07 total
```

Tested under chainer==3.0.0rc1 & cupy==2.0.0rc1.

c.f. https://devblogs.nvidia.com/parallelforall/cuda-pro-tip-understand-fat-binaries-jit-caching/