### PR TITLE
add test scripts to run slow test cases

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -12,9 +12,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Test script for multi-environment')
     parser.add_argument('--test', choices=[
-        'chainer-py2', 'chainer-py3', 'chainer-py35', 'chainer-example',
-        'chainer-prev_example', 'chainer-doc',
-        'cupy-py2', 'cupy-py3', 'cupy-py35', 'cupy-example', 'cupy-doc',
+        'chainer-py2', 'chainer-py3', 'chainer-py35', 'chainer-slow',
+        'chainer-example', 'chainer-prev_example', 'chainer-doc',
+        'cupy-py2', 'cupy-py3', 'cupy-py35', 'cupy-slow',
+        'cupy-example', 'cupy-doc',
     ], required=True)
     parser.add_argument('--no-cache', action='store_true')
     parser.add_argument('--timeout', default='1h')
@@ -75,6 +76,19 @@ if __name__ == '__main__':
             ],
         }
         script = './test.sh'
+
+    elif args.test == 'chainer-slow':
+        conf = {
+            'base': 'ubuntu16_py3',
+            'cuda': 'cuda80',
+            'cudnn': 'cudnn6',
+            'nccl': 'nccl1.3.4',
+            'requires': [
+                'setuptools', 'cython==0.26.1', 'numpy<1.11',
+                'scipy<0.19', 'h5py', 'theano', 'protobuf<3',
+            ],
+        }
+        script = './test_slow.sh'
 
     elif args.test == 'chainer-example':
         conf = {
@@ -148,6 +162,18 @@ if __name__ == '__main__':
             ],
         }
         script = './test_cupy.sh'
+
+    elif args.test == 'cupy-slow':
+        conf = {
+            'base': 'ubuntu16_py3',
+            'cuda': 'cuda80',
+            'cudnn': 'cudnn6',
+            'nccl': 'none',
+            'requires': [
+                'setuptools', 'cython==0.26.1', 'numpy<1.11', 'scipy<0.19',
+            ],
+        }
+        script = './test_cupy_slow.sh'
 
     elif args.test == 'cupy-example':
         conf = {

--- a/run_test.py
+++ b/run_test.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         conf = {
             'base': 'ubuntu16_py3',
             'cuda': 'cuda80',
-            'cudnn': 'cudnn6',
+            'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3.4',
             'requires': [
                 'setuptools', 'cython==0.26.1', 'numpy<1.11',
@@ -167,7 +167,7 @@ if __name__ == '__main__':
         conf = {
             'base': 'ubuntu16_py3',
             'cuda': 'cuda80',
-            'cudnn': 'cudnn6',
+            'cudnn': 'cudnn6-cuda8',
             'nccl': 'none',
             'requires': [
                 'setuptools', 'cython==0.26.1', 'numpy<1.11', 'scipy<0.19',

--- a/test_cupy_slow.sh
+++ b/test_cupy_slow.sh
@@ -7,7 +7,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then
-  nosetests --with-coverage --cover-branches --cover-package=cupy -a '!cudnn,slow' tests
+  python -m pytest --cov-report=xml --cov -m 'slow and not cudnn' tests
 else
-  nosetests --with-coverage --cover-branches --cover-package=cupy -a 'slow' tests
+  python -m pytest --cov-report=xml --cov -m 'slow' tests
 fi

--- a/test_cupy_slow.sh
+++ b/test_cupy_slow.sh
@@ -3,7 +3,6 @@
 cd cupy
 python setup.py build -j 4 develop install --user || python setup.py develop install --user
 
-export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then

--- a/test_cupy_slow.sh
+++ b/test_cupy_slow.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -ex
+
+cd cupy
+python setup.py build -j 4 develop install --user || python setup.py develop install --user
+
+export PYTHONWARNINGS="ignore::FutureWarning"
+export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
+
+if [ $CUDNN = none ]; then
+  nosetests --with-coverage --cover-branches --cover-package=cupy -a '!cudnn,slow' tests
+else
+  nosetests --with-coverage --cover-branches --cover-package=cupy -a 'slow' tests
+fi

--- a/test_cupy_slow.sh
+++ b/test_cupy_slow.sh
@@ -7,7 +7,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then
-  python -m pytest --cov-report=xml --cov -m 'slow and not cudnn' tests
+  python -m pytest --cov -m 'slow and not cudnn' tests
 else
-  python -m pytest --cov-report=xml --cov -m 'slow' tests
+  python -m pytest --cov -m 'slow' tests
 fi

--- a/test_slow.sh
+++ b/test_slow.sh
@@ -12,7 +12,6 @@ cd ..
 
 cd chainer
 
-export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then

--- a/test_slow.sh
+++ b/test_slow.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -ex
+
+# Chainer setup script installs specific version of CuPy.
+# We need to install Chainer first for test.
+cd chainer
+python setup.py install --user
+cd ..
+
+cd cupy
+python setup.py build -j 4 develop install --user || python setup.py develop install --user
+cd ..
+
+cd chainer
+
+export PYTHONWARNINGS="ignore::FutureWarning"
+export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
+
+if [ $CUDNN = none ]; then
+  nosetests --with-coverage --cover-branches --cover-package=chainer -a '!cudnn,slow' tests
+else
+  nosetests --with-coverage --cover-branches --cover-package=chainer -a 'slow' tests
+fi

--- a/test_slow.sh
+++ b/test_slow.sh
@@ -16,7 +16,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then
-  nosetests --with-coverage --cover-branches --cover-package=chainer -a '!cudnn,slow' tests
+  python -m pytest --cov-report=xml --cov -m 'slow and not cudnn' tests
 else
-  nosetests --with-coverage --cover-branches --cover-package=chainer -a 'slow' tests
+  python -m pytest --cov-report=xml --cov -m 'slow' tests
 fi

--- a/test_slow.sh
+++ b/test_slow.sh
@@ -16,7 +16,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 if [ $CUDNN = none ]; then
-  python -m pytest --cov-report=xml --cov -m 'slow and not cudnn' tests
+  python -m pytest --cov -m 'slow and not cudnn' tests
 else
-  python -m pytest --cov-report=xml --cov -m 'slow' tests
+  python -m pytest --cov -m 'slow' tests
 fi


### PR DESCRIPTION
This PR adds scripts to run test cases annotated with `slow`.

Test running time in internal server (excluding docker image build phase):

* `chainer-slow`: 44 minutes
* `cupy-slow`: 1 minute

Currently `cupy-slow` is failing; I'm investigating it.