### PR TITLE
Use python 3.5 for make html and make doctest

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -100,17 +100,13 @@ if __name__ == '__main__':
         # See sphinx version RTD uses:
         # https://github.com/rtfd/readthedocs.org/blob/master/requirements/pip.txt
         conf = {
-            'base': 'ubuntu14_py2',
-            'cuda': 'cuda70',
-            'cudnn': 'cudnn4',
+            'base': 'ubuntu16_py3',
+            'cuda': 'cuda80',
+            'cudnn': 'cudnn6-cuda8',
             'nccl': 'none',
             'requires': [
                 'pip==9.0.1', 'setuptools', 'cython==0.26.1', 'numpy<1.13',
                 'scipy<0.19', 'sphinx==1.5.3', 'sphinx_rtd_theme',
-
-                # Use pyOpenSSL to avoid SNIMissingWarning (Python<2.7.9)
-                # See: http://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
-                'urllib3[secure]',
             ]
         }
         script = './test_doc.sh'
@@ -169,7 +165,7 @@ if __name__ == '__main__':
         # See sphinx version RTD uses:
         # https://github.com/rtfd/readthedocs.org/blob/master/requirements/pip.txt
         conf = {
-            'base': 'ubuntu14_py2',
+            'base': 'ubuntu16_py3',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3.4',


### PR DESCRIPTION
To avoid `cyfunction is not a Python function` as:

```
/work/cupy/docs/source/reference/generated/cupy.cuda.Event.rst:53: WARNING: error while formatting arguments for cupy.cuda.Event.record: <cyfunction Event.record at 0x2aea1bcb8d10> is not a Python function
```

It seems `insepect.isfunction(cyfuction)` returns True from python 3.4 https://groups.google.com/forum/#!topic/cython-users/FvcMPk9n2X8. Using python >= 3.4 resolves the issue.

ref. https://github.com/cupy/cupy/pull/306#issuecomment-338575431

----------

All of three must be merged together:

* this PR
* https://github.com/chainer/chainer/pull/3653
* https://github.com/cupy/cupy/pull/644