### PR TITLE
Add --showlocals PyTest option

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,7 @@ export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 pytest_opts=(
     --timeout=60
     --cov
+    --showlocals  # Show local variables on error
 )
 
 if [ $CUDNN = none ]; then

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 # Chainer setup script installs specific version of CuPy.
 # We need to install Chainer first for test.
@@ -15,10 +15,16 @@ cd chainer
 export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
+pytest_opts=(
+    --timeout=60
+    --cov
+)
+
 if [ $CUDNN = none ]; then
-  python -m pytest --timeout=60 --cov -m 'not cudnn and not slow' tests
+  pytest_opts+=(-m 'not cudnn and not slow')
 else
-  python -m pytest --timeout=60 --cov -m 'not slow' tests
+  pytest_opts+=(-m 'not slow')
 fi
 
+python -m pytest "${pytest_opts[@]}" tests
 python ../push_coveralls.py

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 
 cd chainer
@@ -7,4 +7,10 @@ python setup.py develop install --user
 export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
-python -m pytest --timeout=60 --cov -m 'not gpu and not multi_gpu and not cudnn and not slow' tests/chainer_tests
+pytest_opts=(
+    --timeout=60
+    --cov
+    -m 'not gpu and not multi_gpu and not cudnn and not slow'
+)
+
+python -m pytest "${pytest_opts[@]}" tests/chainer_tests

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -10,6 +10,7 @@ export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 pytest_opts=(
     --timeout=60
     --cov
+    --showlocals  # Show local variables on error
     -m 'not gpu and not multi_gpu and not cudnn and not slow'
 )
 

--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -9,6 +9,7 @@ export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 pytest_opts=(
     --timeout=60
     --cov
+    --showlocals  # Show local variables on error
 )
 
 if [ $CUDNN = none ]; then

--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 cd cupy
 python setup.py build -j 4 develop install --user || python setup.py develop install --user
@@ -6,10 +6,17 @@ python setup.py build -j 4 develop install --user || python setup.py develop ins
 export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
+pytest_opts=(
+    --timeout=60
+    --cov
+)
+
 if [ $CUDNN = none ]; then
-  python -m pytest --timeout=60 --cov -m 'not cudnn and not slow' tests
+  pytest_opts+=(-m 'not cudnn and not slow')
 else
-  python -m pytest --timeout=60 --cov -m 'not slow' tests
+  pytest_opts+=(-m 'not slow')
 fi
+
+python -m pytest "${pytest_opts[@]}" tests
 
 python ../push_coveralls.py


### PR DESCRIPTION
Adds `--showlocals` PyTest option.
(As the compensation for https://github.com/chainer/chainer/pull/3685 which removes it from `setup.cfg`)

I changed so that options are built multi-line using bash array.
(In this way we can put comments on each option, and conflict is less likely to occur.
It introduces dependency to bash, but I think that's not a big deal.)