### PR TITLE
set timeout for each test case for 5 minutes

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 pytest_opts=(
-    --timeout=60
+    --timeout=300
     --cov
     --showlocals  # Show local variables on error
 )

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -8,7 +8,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 pytest_opts=(
-    --timeout=60
+    --timeout=300
     --cov
     --showlocals  # Show local variables on error
     -m 'not gpu and not multi_gpu and not cudnn and not slow'

--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -7,7 +7,7 @@ export PYTHONWARNINGS="ignore::FutureWarning"
 export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 pytest_opts=(
-    --timeout=60
+    --timeout=300
     --cov
     --showlocals  # Show local variables on error
 )


### PR DESCRIPTION
Sometimes test cases (esp. the first CUDA call) takes roughly 3 minutes.
We need to relax the timeout parameter.