### PR TITLE
Revert scipy 1.0

### DIFF
--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -15,7 +15,7 @@ params = {
     'cuda_cudnn': docker.get_cuda_cudnn_choices('cupy'),
     'nccl': docker.nccl_choices,
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '0.18', '0.19', '1.0'],
+    'scipy': [None, '0.18', '0.19'],
 }
 
 


### PR DESCRIPTION
I found some compatibility break in scipy 1.0. I reverted this version.