### PR TITLE
use SIGINT instead of SIGTERM for timeout

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -554,9 +554,10 @@ def run_with(conf, script, no_cache=False, volume=None, env=None,
 
     cmd.append(name)
     if timeout:
-        # First send SIGINT, and if the command is still running after 1 minute,
-        # send SIGKILL.
-        cmd += ['timeout', '--signal', 'INT', '--kill-after', '1m', str(timeout)]
+        # First send SIGINT, and if the command is still running after
+        # 1 minute, send SIGKILL.
+        cmd += ['timeout', '--signal', 'INT',
+                '--kill-after', '1m', str(timeout)]
     cmd.append(script)
 
     res = subprocess.call(cmd)

--- a/docker.py
+++ b/docker.py
@@ -554,7 +554,9 @@ def run_with(conf, script, no_cache=False, volume=None, env=None,
 
     cmd.append(name)
     if timeout:
-        cmd += ['timeout', str(timeout)]
+        # First send SIGINT, and if the command is still running after 1 minute,
+        # send SIGKILL.
+        cmd += ['timeout', '--signal', 'INT', '--kill-after', '1m', str(timeout)]
     cmd.append(script)
 
     res = subprocess.call(cmd)


### PR DESCRIPTION
Currently test process is immediately killed by SIGTERM.
`pytest` report nothing when killed by SIGTERM, which makes hard to investigate why timeout occurred.