### PR TITLE
Revert "use SIGINT instead of SIGTERM for timeout"

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -554,10 +554,7 @@ def run_with(conf, script, no_cache=False, volume=None, env=None,
 
     cmd.append(name)
     if timeout:
-        # First send SIGINT, and if the command is still running after
-        # 1 minute, send SIGKILL.
-        cmd += ['timeout', '--signal', 'INT',
-                '--kill-after', '1m', str(timeout)]
+        cmd += ['timeout', str(timeout)]
     cmd.append(script)
 
     res = subprocess.call(cmd)


### PR DESCRIPTION
Reverts chainer/chainer-test#360