### PR TITLE
remove scipy 0.18 from combination test

### DIFF
--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -15,7 +15,7 @@ params = {
     'cuda_cudnn': docker.get_cuda_cudnn_choices('cupy'),
     'nccl': docker.nccl_choices,
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '0.18', '0.19'],
+    'scipy': [None, '0.19'],
 }
 
 


### PR DESCRIPTION
As SciPy 0.18 is not compatible with Python 3.6, we skip it from test variation generation.

https://github.com/scipy/scipy/releases/tag/v0.18.0

Note that SciPy 0.18 case is still covered by `run_test.py`.