### PR TITLE
add matplotlib for doctest

### DIFF
--- a/test_doc.sh
+++ b/test_doc.sh
@@ -7,6 +7,8 @@ cd ..
 cd chainer
 python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
 
+python -m pip install matplotlib --user
+
 cd docs
 make html
 make clean


### PR DESCRIPTION
Doctest will require matplotlib by this PR: https://github.com/chainer/chainer/pull/3942