### PR TITLE
preserve built HTML for preview

### DIFF
--- a/test_cupy_doc.sh
+++ b/test_cupy_doc.sh
@@ -4,8 +4,13 @@ cd cupy
 python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
 
 cd docs
+
+# Generate HTML and preserve it for preview.
 make html
-make clean
+mv build/html preview
+
+# Run doctest.
 # The doctest has some bug. We need two pass doctest
+make clean
 make doctest
 make doctest

--- a/test_doc.sh
+++ b/test_doc.sh
@@ -8,8 +8,13 @@ cd chainer
 python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
 
 cd docs
+
+# Generate HTML and preserve it for preview.
 make html
-make clean
+mv build/html preview
+
+# Run doctest.
 # The doctest has some bug. We need two pass doctest
+make clean
 make doctest
 make doctest


### PR DESCRIPTION
This fixes #336.
The `preview` directory will later be saved as an artifact in Jenkins.

This will make review for document fixes easier.