### PR TITLE
[WIP] add cuda/cudnn/nccl matrix generator

### DIFF
--- a/cuda_matrix_generator.py
+++ b/cuda_matrix_generator.py
@@ -48,7 +48,9 @@ def _get_fully_qualified_version_id(cuda, libver, matrix):
 
 
 def get_cudnn_id(cuda, cudnn):
-    """Translate cuDNN version (without CUDA version suffix) into
+    """Returns translated version representation of cuDNN.
+
+    This method translates cuDNN version (without CUDA version suffix) into
     fully-qualified version identifier.
 
     e.g., ('cuda70', 'cudnn6') -> 'cudnn6'
@@ -58,7 +60,9 @@ def get_cudnn_id(cuda, cudnn):
 
 
 def get_nccl_id(cuda, nccl):
-    """Translate NCCL version (without CUDA version suffix) into
+    """Returns translated version representation of NCCL.
+
+    This method translates NCCL version (without CUDA version suffix) into
     fully-qualified version identifier.
 
     e.g., ('cuda70', 'nccl1.3.4') -> 'nccl1.3.4'

--- a/cuda_matrix_generator.py
+++ b/cuda_matrix_generator.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+
+import docker
+
+
+def _generate_matrix(libname, matrix):
+    """Generate Groovy expression of all acceptable version combinations.
+
+    This can be used for Jenkins configuration.
+    """
+    conditions = []
+    for cuda in sorted(matrix.keys()):
+        versions = sorted(set(
+            [fq_libver.split('-')[0] for fq_libver in matrix[cuda]]))
+        conditions += [
+            '(CUDA == \'{}\' && {} in {})'.format(cuda, libname, versions)
+        ]
+
+    return ' || '.join(conditions)
+
+
+def generate_cudnn_matrix():
+    return _generate_matrix('CUDNN', docker.cuda_cudnns)
+
+
+def generate_nccl_matrix():
+    return _generate_matrix('NCCL', docker.cuda_nccls)
+
+
+def _get_fully_qualified_version_id(cuda, libver, matrix):
+    if cuda == 'none':
+        if libver != 'none':
+            raise RuntimeError('library version must be none if cuda is none')
+        return libver
+    elif cuda not in matrix.keys():
+        raise RuntimeError(
+            'unsupported cuda version: '
+            'must be any of: {}'.format(matrix.keys()))
+
+    for fq_libver in sorted(matrix[cuda]):
+        if libver == fq_libver or fq_libver.startswith('{}-'.format(libver)):
+            return fq_libver
+
+    raise RuntimeError('unsupported library version: {}'.format(libver))
+
+
+def get_cudnn_id(cuda, cudnn):
+    """Translate cuDNN version (without CUDA version suffix) into
+    fully-qualified version identifier.
+
+    e.g., ('cuda70', 'cudnn6') -> 'cudnn6'
+          ('cuda80', 'cudnn6') -> 'cudnn6-cuda8'
+    """
+    return _get_fully_qualified_version_id(cuda, cudnn, docker.cuda_cudnns)
+
+
+def get_nccl_id(cuda, nccl):
+    """Translate NCCL version (without CUDA version suffix) into
+    fully-qualified version identifier.
+
+    e.g., ('cuda70', 'nccl1.3.4') -> 'nccl1.3.4'
+          ('cuda80', 'nccl2.0')   -> 'nccl2.0-cuda8'
+    """
+    return _get_fully_qualified_version_id(cuda, nccl, docker.cuda_nccls)
+
+
+def main(args):
+    parser = argparse.ArgumentParser(
+        description='CUDA Matrix Test Generator')
+    parser.add_argument('--generate-cudnn-matrix', action='store_true')
+    parser.add_argument('--generate-nccl-matrix', action='store_true')
+    parser.add_argument('--get-cudnn-id', action='store_true')
+    parser.add_argument('--get-nccl-id', action='store_true')
+
+    # For --get-{cudnn,nccl}-id:
+    parser.add_argument('--cuda', default='none')
+    parser.add_argument('--cudnn', default='none')
+    parser.add_argument('--nccl', default='none')
+
+    params = parser.parse_args(args)
+
+    if params.get_cudnn_id:
+        print(get_cudnn_id(params.cuda, params.cudnn))
+    elif params.get_nccl_id:
+        print(get_nccl_id(params.cuda, params.nccl))
+    elif params.generate_cudnn_matrix:
+        print(generate_cudnn_matrix())
+    elif params.generate_nccl_matrix:
+        print(generate_nccl_matrix())
+    else:
+        parser.error('no action specified')
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/cuda_matrix_generator.py
+++ b/cuda_matrix_generator.py
@@ -12,9 +12,10 @@ def _generate_matrix(libname, matrix):
     This can be used for Jenkins configuration.
     """
     conditions = []
-    for cuda in sorted(matrix.keys()):
+    for cuda in sorted(matrix.keys()) + ['none']:
+        fq_versions = matrix.get(cuda, []) + ['none']
         versions = sorted(set(
-            [fq_libver.split('-')[0] for fq_libver in matrix[cuda]]))
+            [fq_ver.split('-')[0] for fq_ver in fq_versions]))
         conditions += [
             '(CUDA == \'{}\' && {} in {})'.format(cuda, libname, versions)
         ]


### PR DESCRIPTION
<img width="459" alt="build_matrix_example" src="https://user-images.githubusercontent.com/939877/33919350-99ca5770-dffb-11e7-9e0e-ffc40d791b78.png">

This makes easy to define Jenkins job to test all possible cuda/cudnn/nccl version combinations.

Usage 1:

```
$ ./cuda_matrix_generator.py --generate-cudnn-matrix
(CUDA == 'cuda70' && CUDNN in ['cudnn4']) || (CUDA == 'cuda75' && CUDNN in ['cudnn4', 'cudnn5', 'cudnn51', 'cudnn6']) || (CUDA == 'cuda80' && CUDNN in ['cudnn5', 'cudnn51', 'cudnn6', 'cudnn7']) || (CUDA == 'cuda90' && CUDNN in ['cudnn7'])
```

The output is used to configure Jenkins to define valid combinations.

Usage 2:

```
$ ./cuda_matrix_generator.py --get-cudnn-id --cuda cuda80 --cudnn cudnn7
cudnn7-cuda8
```

The output is used for `--cudnn` argument of `run_multi_test.py` script.