### PR TITLE
Fix duplicate requirements in shuffle tests

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -4,6 +4,7 @@ import sys
 
 import six
 
+import docker
 
 def iter_shuffle(lst):
     while True:
@@ -51,7 +52,14 @@ def make_require(name, version):
 def append_require(params, conf, name):
     version = params.get(name)
     if version:
-        conf['requires'].append(make_require(name, version))
+        overwrite_requires_version(conf, name, make_require(name, version))
+
+
+def overwrite_requires_version(conf, name, requirement):
+    # Overwrite the requirements for the package `name` already
+    # defined in `requires`.
+    _, conf['requires'] = docker.partition_requirements(name, conf['requires'])
+    conf['requires'].append(requirement)
 
 
 def make_conf(params):
@@ -72,7 +80,7 @@ def make_conf(params):
 
     if params.get('h5py') == '2.5':
         # NumPy is required to install h5py in this version
-        conf['requires'].append('numpy<1.10')
+        overwrite_requires_version(conf, 'numpy', 'numpy<1.10')
     append_require(params, conf, 'h5py')
 
     append_require(params, conf, 'theano')

--- a/shuffle.py
+++ b/shuffle.py
@@ -97,8 +97,17 @@ def make_conf(params):
 
 def make_shuffle_conf(params, index):
     params = get_shuffle_params(params, index)
+
+    print('--- Shuffle Parameters ---')
     for key, value in params.items():
         print('{}: {}'.format(key, value))
     sys.stdout.flush()
 
-    return make_conf(params)
+    conf = make_conf(params)
+
+    print('--- Configuration ---')
+    for key, value in conf.items():
+        print('{}: {}'.format(key, value))
+    sys.stdout.flush()
+
+    return conf

--- a/shuffle.py
+++ b/shuffle.py
@@ -6,6 +6,7 @@ import six
 
 import docker
 
+
 def iter_shuffle(lst):
     while True:
         l = list(lst)


### PR DESCRIPTION
When `h5py == 2.5` is picked by shuffle, it appends `numpy<1.10` requirement.
However, due to fix introduced in #380, this generates Dockerfile like:

```
RUN pip install -U "setuptools" "pip" "cython==0.26.1" "numpy<1.11" "numpy<1.10" "h5py<2.6" "protobuf<4" "pytest" "pytest-timeout" "pytest-cov" "nose" "mock" "coveralls" && rm -rf ~/.cache/pip
```

which declares NumPy requirements twice, which results in pip error:

```
Double requirement given: numpy<1.10 (already in numpy<1.11, name='numpy')
```