### PR TITLE
Avoid using unsupported NumPy/SciPy version for the base Python version

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -10,9 +10,11 @@ import version
 
 
 base_choices = [
-    'ubuntu14_py2', 'ubuntu14_py3', 'ubuntu14_py35', 'ubuntu14_py36',
-    'ubuntu16_py2', 'ubuntu16_py3',
-    'centos6_py2', 'centos7_py2', 'centos7_py3']
+    'ubuntu14_py27', 'ubuntu14_py34',
+    'ubuntu14_py35-pyenv', 'ubuntu14_py36-pyenv',
+    'ubuntu16_py27', 'ubuntu16_py35',
+    'centos6_py27-pyenv',
+    'centos7_py27', 'centos7_py34-pyenv']
 cuda_choices = ['none', 'cuda70', 'cuda75', 'cuda80', 'cuda90']
 cudnn_choices = [
     'none', 'cudnn4', 'cudnn5', 'cudnn5-cuda8', 'cudnn51',
@@ -78,7 +80,7 @@ codes = {}
 
 # base
 
-codes['centos7_py2'] = '''FROM centos:7
+codes['centos7_py27'] = '''FROM centos:7
 
 ENV PATH /usr/lib64/ccache:$PATH
 
@@ -89,7 +91,7 @@ RUN yum -y update && \\
     yum clean all
 '''
 
-codes['centos7_py3'] = '''FROM centos:7
+codes['centos7_py34-pyenv'] = '''FROM centos:7
 
 ENV PATH /usr/lib64/ccache:$PATH
 
@@ -110,7 +112,7 @@ RUN pyenv global 3.4.7
 RUN pyenv rehash
 '''
 
-codes['centos6_py2'] = '''FROM centos:6
+codes['centos6_py27-pyenv'] = '''FROM centos:6
 
 ENV PATH /usr/lib64/ccache:$PATH
 
@@ -131,7 +133,7 @@ RUN pyenv global 2.7.14
 RUN pyenv rehash
 '''
 
-codes['ubuntu14_py2'] = '''FROM ubuntu:14.04
+codes['ubuntu14_py27'] = '''FROM ubuntu:14.04
 
 ENV PATH /usr/lib/ccache:$PATH
 
@@ -143,7 +145,7 @@ RUN apt-get -y update && \\
     apt-get clean
 '''
 
-codes['ubuntu14_py3'] = '''FROM ubuntu:14.04
+codes['ubuntu14_py34'] = '''FROM ubuntu:14.04
 
 ENV PATH /usr/lib/ccache:$PATH
 
@@ -178,10 +180,10 @@ RUN pyenv global {python_ver}
 RUN pyenv rehash
 '''
 
-codes['ubuntu14_py35'] = ubuntu14_pyenv_base.format(python_ver='3.5.4')
-codes['ubuntu14_py36'] = ubuntu14_pyenv_base.format(python_ver='3.6.3')
+codes['ubuntu14_py35-pyenv'] = ubuntu14_pyenv_base.format(python_ver='3.5.4')
+codes['ubuntu14_py36-pyenv'] = ubuntu14_pyenv_base.format(python_ver='3.6.3')
 
-codes['ubuntu16_py2'] = '''FROM ubuntu:16.04
+codes['ubuntu16_py27'] = '''FROM ubuntu:16.04
 
 ENV PATH /usr/lib/ccache:$PATH
 
@@ -195,7 +197,7 @@ RUN ln -s /usr/bin/gcc-4.8 /usr/local/bin/gcc
 RUN ln -s /usr/bin/g++-4.8 /usr/local/bin/g++
 '''
 
-codes['ubuntu16_py3'] = '''FROM ubuntu:16.04
+codes['ubuntu16_py35'] = '''FROM ubuntu:16.04
 
 ENV PATH /usr/lib/ccache:$PATH
 

--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     # make sdist
     # cuda, cudnn and numpy is required to make a sdist file.
     build_conf = {
-        'base': 'ubuntu14_py2',
+        'base': 'ubuntu14_py27',
         'cuda': 'cuda70',
         'cudnn': 'cudnn4',
         'nccl': 'none',

--- a/run_install_test.py
+++ b/run_install_test.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     build_conf = {
-        'base': 'ubuntu14_py2',
+        'base': 'ubuntu14_py27',
         'cuda': 'none',
         'cudnn': 'none',
         'nccl': 'none',

--- a/run_test.py
+++ b/run_test.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
 
     if args.test == 'chainer-py2':
         conf = {
-            'base': 'ubuntu14_py2',
+            'base': 'ubuntu14_py27',
             'cuda': 'cuda70',
             'cudnn': 'cudnn4',
             'nccl': 'none',
@@ -52,7 +52,7 @@ if __name__ == '__main__':
 
     elif args.test == 'chainer-py3':
         conf = {
-            'base': 'ubuntu14_py3',
+            'base': 'ubuntu14_py34',
             'cuda': 'cuda80',
             'cudnn': 'cudnn51-cuda8',
             'nccl': 'nccl1.3.4',
@@ -66,7 +66,7 @@ if __name__ == '__main__':
 
     elif args.test == 'chainer-py35':
         conf = {
-            'base': 'ubuntu16_py3',
+            'base': 'ubuntu16_py35',
             'cuda': 'cuda90',
             'cudnn': 'cudnn7-cuda9',
             'nccl': 'nccl2.0-cuda9',
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     elif args.test == 'chainer-slow':
         conf = {
-            'base': 'ubuntu16_py3',
+            'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3.4',
@@ -92,7 +92,7 @@ if __name__ == '__main__':
 
     elif args.test == 'chainer-example':
         conf = {
-            'base': 'centos7_py2',
+            'base': 'centos7_py27',
             'cuda': 'cuda75',
             'cudnn': 'cudnn6',
             'nccl': 'nccl1.3.4',
@@ -102,7 +102,7 @@ if __name__ == '__main__':
 
     elif args.test == 'chainer-prev_example':
         conf = {
-            'base': 'ubuntu14_py2',
+            'base': 'ubuntu14_py27',
             'cuda': 'cuda90',
             'cudnn': 'cudnn7-cuda9',
             'nccl': 'none',
@@ -114,7 +114,7 @@ if __name__ == '__main__':
         # See sphinx version RTD uses:
         # https://github.com/rtfd/readthedocs.org/blob/master/requirements/pip.txt
         conf = {
-            'base': 'ubuntu16_py3',
+            'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'none',
@@ -128,7 +128,7 @@ if __name__ == '__main__':
 
     elif args.test == 'cupy-py2':
         conf = {
-            'base': 'ubuntu14_py2',
+            'base': 'ubuntu14_py27',
             'cuda': 'cuda70',
             'cudnn': 'cudnn4',
             'nccl': 'none',
@@ -141,7 +141,7 @@ if __name__ == '__main__':
 
     elif args.test == 'cupy-py3':
         conf = {
-            'base': 'ubuntu14_py3',
+            'base': 'ubuntu14_py34',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3.4',
@@ -154,7 +154,7 @@ if __name__ == '__main__':
 
     elif args.test == 'cupy-py35':
         conf = {
-            'base': 'ubuntu16_py3',
+            'base': 'ubuntu16_py35',
             'cuda': 'cuda90',
             'cudnn': 'cudnn7-cuda9',
             'nccl': 'nccl2.0-cuda9',
@@ -166,7 +166,7 @@ if __name__ == '__main__':
 
     elif args.test == 'cupy-slow':
         conf = {
-            'base': 'ubuntu16_py3',
+            'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'none',
@@ -178,7 +178,7 @@ if __name__ == '__main__':
 
     elif args.test == 'cupy-example':
         conf = {
-            'base': 'centos7_py2',
+            'base': 'centos7_py27',
             'cuda': 'cuda75',
             'cudnn': 'cudnn5',
             'nccl': 'nccl1.3.4',
@@ -192,7 +192,7 @@ if __name__ == '__main__':
         # See sphinx version RTD uses:
         # https://github.com/rtfd/readthedocs.org/blob/master/requirements/pip.txt
         conf = {
-            'base': 'ubuntu16_py3',
+            'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3.4',

--- a/shuffle.py
+++ b/shuffle.py
@@ -24,6 +24,19 @@ def get_shuffle_params(params, index):
     if ret['numpy'] == '1.9' and ret.get('h5py'):
         ret['numpy'] = '1.10'
 
+    # Avoid unsupported NumPy/SciPy version for the Python version.
+    if 'py35' in ret['base']:
+        # Python 3.5 is first supported in NumPy 1.11.
+        if ret['numpy'] in ['1.9', '1.10']:
+            ret['numpy'] = '1.11'
+    elif 'py36' in ret['base']:
+        # Python 3.6 is first supported in NumPy 1.12.
+        if ret['numpy'] in ['1.9', '1.10', '1.11']:
+            ret['numpy'] = '1.12'
+        # Python 3.6 is first supported in SciPy 1.19.
+        if ret.get('scipy', None) in ['0.18']:
+            ret['scipy'] = '0.19'
+
     cuda, cudnn, nccl = ret['cuda_cudnn_nccl']
     if ('centos6' in ret['base'] or
             'ubuntu16' in ret['base'] and cuda < 'cuda8'):


### PR DESCRIPTION
Currently, combinations generated by shuffle test may contain unsupported configuration. For example, [SciPy 0.18.0](https://docs.scipy.org/doc/scipy/reference/release.0.18.0.html#scipy-0-18-0-release-notes) and [NumPy 1.11](https://docs.scipy.org/doc/numpy-1.11.0/release.html) does not support Python 3.6.

This PR changes the `base` name (which is a label of OS name + Python version) to include the detailed Python version (e.g., `py35` instead of `py3`), and fix the generated configuration if unsupported combination is generated.