### PR TITLE
install google-glog for iDeep tests

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -533,7 +533,8 @@ RUN apt-get remove -y \\
                 dockerfile += 'RUN apt-get update && apt-get -y install libgoogle-glog0 && apt-get clean\n'
             else:
                 # TODO(kmaehashi) support CentOS 7
-                raise RuntimeError('ideep4py test not supported on this system so far')
+                raise RuntimeError(
+                    'ideep4py test not supported on this system so far')
 
         pillow, requires = partition_requirements('pillow', requires)
         scipy, requires = partition_requirements('scipy', requires)

--- a/docker.py
+++ b/docker.py
@@ -526,6 +526,15 @@ RUN apt-get remove -y \\
             elif 'centos' in conf['base']:
                 dockerfile += 'RUN yum -y update && yum -y install lapack-devel && yum clean all\n'
 
+        if any(['ideep4py' in req for req in requires]):
+            if 'ubuntu16' in conf['base']:
+                dockerfile += 'RUN apt-get update && apt-get -y install libgoogle-glog0v5 && apt-get clean\n'
+            elif 'ubuntu14' in conf['base']:
+                dockerfile += 'RUN apt-get update && apt-get -y install libgoogle-glog0 && apt-get clean\n'
+            else:
+                # TODO(kmaehashi) support CentOS 7
+                raise RuntimeError('ideep4py test not supported on this system so far')
+
         pillow, requires = partition_requirements('pillow', requires)
         scipy, requires = partition_requirements('scipy', requires)
 

--- a/shuffle.py
+++ b/shuffle.py
@@ -57,6 +57,10 @@ def get_shuffle_params(params, index):
     if not _is_ideep_supported(py_ver):
         ret['ideep'] = None
 
+    # TODO(kmaehashi) Currently iDeep can only be tested on Ubuntu.
+    if not 'ubuntu' in ret['base']:
+        ret['ideep'] = None
+
     cuda, cudnn, nccl = ret['cuda_cudnn_nccl']
     if ('centos6' in ret['base'] or
             'ubuntu16' in ret['base'] and cuda < 'cuda8'):

--- a/shuffle.py
+++ b/shuffle.py
@@ -58,7 +58,7 @@ def get_shuffle_params(params, index):
         ret['ideep'] = None
 
     # TODO(kmaehashi) Currently iDeep can only be tested on Ubuntu.
-    if not 'ubuntu' in ret['base']:
+    if 'ubuntu' not in ret['base']:
         ret['ideep'] = None
 
     cuda, cudnn, nccl = ret['cuda_cudnn_nccl']


### PR DESCRIPTION
Currently, to use iDeep4py on vanilla Ubuntu, you need to install `libpython` (for `libpython2.7.so.1.0`) and `libgoogle-glog` (for `libglog.so.0`).