### PR TITLE
Fix for iDeep tests to run

### DIFF
--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -52,8 +52,13 @@ if __name__ == '__main__':
         'coveralls',
     ]
 
+    use_ideep = any(['ideep4py' in req for req in conf['requires']])
+
     volume = []
-    env = {'CUDNN': conf['cudnn']}
+    env = {
+        'CUDNN': conf['cudnn'],
+        'IDEEP': 'ideep4py' if use_ideep else 'none',
+    }
 
     argconfig.parse_args(args, env, conf, volume)
     argconfig.set_coveralls(args, env)

--- a/run_multi_test.py
+++ b/run_multi_test.py
@@ -39,8 +39,6 @@ if __name__ == '__main__':
         'nccl': args.nccl,
         'requires': ['setuptools', 'pip', 'cython==0.26.1'],
     }
-    volume = []
-    env = {'CUDNN': conf['cudnn']}
 
     if args.h5py == '2.5':
         conf['requires'].append('numpy<1.10')
@@ -80,6 +78,14 @@ if __name__ == '__main__':
 
     if args.ideep != 'none':
         conf['requires'].append('ideep4py=={}'.format(args.ideep))
+
+    use_ideep = any(['ideep4py' in req for req in conf['requires']])
+
+    volume = []
+    env = {
+        'CUDNN': conf['cudnn'],
+        'IDEEP': 'ideep4py' if use_ideep else 'none',
+    }
 
     conf['requires'] += [
         'pytest',

--- a/run_test.py
+++ b/run_test.py
@@ -216,8 +216,13 @@ if __name__ == '__main__':
     else:
         raise
 
+    use_ideep = any(['ideep4py' in req for req in conf['requires']])
+
     volume = []
-    env = {'CUDNN': conf['cudnn']}
+    env = {
+        'CUDNN': conf['cudnn'],
+        'IDEEP': 'ideep4py' if use_ideep else 'none',
+    }
     conf['requires'] += [
         'pytest',
         'pytest-timeout',  # For timeout

--- a/run_test.py
+++ b/run_test.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
             'cudnn': 'cudnn4',
             'nccl': 'none',
             'requires': [
-                'setuptools', 'pip', 'cython==0.26.1', 'numpy<1.14',
+                'setuptools', 'pip', 'cython==0.26.1', 'numpy<1.10',
                 'scipy<0.19', 'h5py', 'theano', 'pillow',
                 'protobuf',  # ignore broken protobuf 3.2.0rc1
             ]
@@ -71,7 +71,7 @@ if __name__ == '__main__':
             'cudnn': 'cudnn7-cuda9',
             'nccl': 'nccl2.0-cuda9',
             'requires': [
-                'setuptools', 'cython==0.26.1', 'numpy<1.10',
+                'setuptools', 'cython==0.26.1', 'numpy<1.14',
                 'scipy<0.19', 'h5py', 'theano', 'protobuf<3',
                 'ideep4py==1.0.2',
             ],
@@ -85,7 +85,7 @@ if __name__ == '__main__':
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3.4',
             'requires': [
-                'setuptools', 'cython==0.26.1', 'numpy<1.11',
+                'setuptools', 'cython==0.26.1', 'numpy<1.14',
                 'scipy<0.19', 'h5py', 'theano', 'protobuf<3',
                 'pillow',
                 'ideep4py==1.0.2',

--- a/shuffle.py
+++ b/shuffle.py
@@ -119,7 +119,7 @@ def make_conf(params):
     append_require(params, conf, 'numpy')
     append_require(params, conf, 'scipy')
 
-    # Note: h5py 2.5 uses NumPy is its setup script and NumPy needs to be
+    # Note: h5py 2.5 uses NumPy in its setup script, so NumPy needs to be
     # installed before h5py.
     append_require(params, conf, 'h5py')
 

--- a/shuffle.py
+++ b/shuffle.py
@@ -61,6 +61,11 @@ def get_shuffle_params(params, index):
     if 'ubuntu' not in ret['base']:
         ret['ideep'] = None
 
+    # iDeep requires NumPy 1.13.0 or later.
+    if ret.get('ideep'):
+        if ret['numpy'] in ['1.9', '1.10', '1.11', '1.12']:
+            ret['numpy'] = '1.13'
+
     cuda, cudnn, nccl = ret['cuda_cudnn_nccl']
     if ('centos6' in ret['base'] or
             'ubuntu16' in ret['base'] and cuda < 'cuda8'):

--- a/shuffle.py
+++ b/shuffle.py
@@ -132,8 +132,8 @@ def make_conf(params):
         append_require(params, conf, 'protobuf')
 
     if params.get('ideep') is not None:
-        append_require(
-            params, conf, 'ideep4py=={}'.format(params.get('ideep')))
+        overwrite_requires_version(
+            conf, 'ideep4py', 'ideep4py=={}'.format(params.get('ideep')))
 
     append_require(params, conf, 'pillow')
 

--- a/shuffle.py
+++ b/shuffle.py
@@ -119,9 +119,8 @@ def make_conf(params):
     append_require(params, conf, 'numpy')
     append_require(params, conf, 'scipy')
 
-    if params.get('h5py') == '2.5':
-        # NumPy is required to install h5py in this version
-        overwrite_requires_version(conf, 'numpy', 'numpy<1.10')
+    # Note: h5py 2.5 uses NumPy is its setup script and NumPy needs to be
+    # installed before h5py.
     append_require(params, conf, 'h5py')
 
     append_require(params, conf, 'theano')

--- a/test.sh
+++ b/test.sh
@@ -21,11 +21,19 @@ pytest_opts=(
     --showlocals  # Show local variables on error
 )
 
+pytest_marks=(
+    not slow
+)
+
 if [ $CUDNN = none ]; then
-  pytest_opts+=(-m 'not cudnn and not slow')
-else
-  pytest_opts+=(-m 'not slow')
+  pytest_marks+=(and not cudnn)
 fi
+
+if [ $IDEEP = none ]; then
+  pytest_marks+=(and not ideep)
+fi
+
+pytest_opts+=(-m "${pytest_marks[*]}")
 
 python -m pytest "${pytest_opts[@]}" tests
 python ../push_coveralls.py

--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -13,7 +13,16 @@ pytest_opts=(
     --junit-xml=result.xml
     --cov
     --showlocals  # Show local variables on error
-    -m 'not cudnn and not slow'
 )
+
+pytest_marks=(
+    not cudnn and not slow
+)
+
+if [ $IDEEP = none ]; then
+  pytest_marks+=(and not ideep)
+fi
+
+pytest_opts+=(-m "${pytest_marks[*]}")
 
 python -m pytest "${pytest_opts[@]}" tests/chainer_tests

--- a/test_slow.sh
+++ b/test_slow.sh
@@ -21,10 +21,18 @@ pytest_opts=(
     --showlocals  # Show local variables on error
 )
 
+pytest_marks=(
+    slow
+)
+
 if [ $CUDNN = none ]; then
-  pytest_opts+=(-m 'slow and not cudnn')
-else
-  pytest_opts+=(-m 'slow')
+  pytest_marks+=(and not cudnn)
 fi
+
+if [ $IDEEP = none ]; then
+  pytest_marks+=(and not ideep)
+fi
+
+pytest_opts+=(-m "${pytest_marks[*]}")
 
 python -m pytest "${pytest_opts[@]}" tests


### PR DESCRIPTION
* Disable tests with `ideep` attribute when iDeep is unavailable.
* Use NumPy >= 1.13.0 for iDeep test.

I confirmed that `import ideep4py` succeeds with the image.