### PR TITLE
Support pip 10.0

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -570,7 +570,8 @@ RUN apt-get remove -y \\
         python3-pip python-pip python-pip-whl \\
         python3-six python-six python-six-whl \\
         python3-setuptools python-setuptools python-setuptools-whl \\
-        python-pkg-resources python3-pkg-resources
+        python-pkg-resources python3-pkg-resources \\
+        python3-chardet python-chardet python-chardet-whl
 '''
 
     if 'requires' in conf:

--- a/docker.py
+++ b/docker.py
@@ -590,9 +590,10 @@ RUN apt-get remove -y \\
                            'pip install --global-option="build_ext" '
                            '--global-option="--disable-jpeg" -U "%s" && rm -rf ~/.cache/pip\n' % pillow)
 
-        dockerfile += (
-            'RUN pip install -U %s && rm -rf ~/.cache/pip\n' %
-            ' '.join(['"%s"' % req for req in requires]))
+        if 0 < len(requires):
+            dockerfile += (
+                'RUN pip install -U %s && rm -rf ~/.cache/pip\n' %
+                ' '.join(['"%s"' % req for req in requires]))
 
         if scipy is not None:
             # SciPy depends on C-API interface of NumPy.


### PR DESCRIPTION
* `pip` 10.0, released yesterday, seems (mistakenly?) tries to remove packages provided by OS (e.g., installed via `apt`), which causes the docker image build to fail. The chardet package provided by OS conflict with newer chardet, which we need to install as a dependency of coveralls package. Formerly `chardet` provided by OS was silently ignored.
* `pip` 10.0 now fails if `pip install -U` (ie, invoked without specifying requirement packages). Formerly it was silently ignored.