### PR TITLE
Use ccache 3.4.2 to improve handling of NVCC compile

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -237,8 +237,8 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 # ccache
 
 ccache = '''WORKDIR /opt/ccache
-RUN curl -L -s -o ccache.tar.gz https://github.com/ccache/ccache/archive/v3.3.4.tar.gz && \\
-    tar -xzf ccache.tar.gz && cd ccache-3.3.4 && \\
+RUN curl -L -s -o ccache.tar.gz https://github.com/ccache/ccache/archive/v3.4.2.tar.gz && \\
+    tar -xzf ccache.tar.gz && cd ccache-3.4.2 && \\
     ./autogen.sh && ./configure && make && \\
     cp ccache /usr/bin/ccache && \\
     cd / && rm -rf /opt/ccache && \\


### PR DESCRIPTION
[This](https://ccache.samba.org/releasenotes.html#_ccache_3_4_2) is release note of the ccache.

