### PR TITLE
Update sphinx version used for test

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -8,6 +8,21 @@ import docker
 import version
 
 
+# See sphinx version RTD uses:
+# https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/python_environments.py
+SPHINX_REQUIREMENTS = [
+    'Pygments==2.2.0',
+    'docutils==0.13.1',
+    'mock==1.0.1',
+    'pillow==2.6.1',
+    'alabaster>=0.7,<0.8,!=0.7.5',
+    'commonmark==0.5.4',
+    'recommonmark==0.4.0',
+    'sphinx<1.8',
+    'sphinx-rtd-theme<0.5',
+]
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Test script for multi-environment')
@@ -114,9 +129,7 @@ if __name__ == '__main__':
         script = './test_prev_example.sh'
 
     elif args.test == 'chainer-doc':
-        # See sphinx version RTD uses:
-        # https://github.com/rtfd/readthedocs.org/blob/master/requirements/pip.txt
-        # Also note that NumPy 1.14 or later is required to run doctest, as
+        # Note that NumPy 1.14 or later is required to run doctest, as
         # the document uses new textual representation of arrays introduced in
         # NumPy 1.14.
         conf = {
@@ -126,10 +139,9 @@ if __name__ == '__main__':
             'nccl': 'none',
             'requires': [
                 'pip==9.0.1', 'setuptools', 'cython==0.28.3', 'matplotlib',
-                'numpy>=1.14', 'scipy<0.19', 'theano', 'sphinx==1.5.3',
-                'sphinx_rtd_theme',
+                'numpy>=1.14', 'scipy<0.19', 'theano',
                 'ideep4py<1.1',
-            ]
+            ] + SPHINX_REQUIREMENTS
         }
         script = './test_doc.sh'
 
@@ -196,9 +208,7 @@ if __name__ == '__main__':
         script = './test_cupy_example.sh'
 
     elif args.test == 'cupy-doc':
-        # See sphinx version RTD uses:
-        # https://github.com/rtfd/readthedocs.org/blob/master/requirements/pip.txt
-        # Also note that NumPy 1.14 or later is required to run doctest, as
+        # Note that NumPy 1.14 or later is required to run doctest, as
         # the document uses new textual representation of arrays introduced in
         # NumPy 1.14.
         conf = {
@@ -208,8 +218,8 @@ if __name__ == '__main__':
             'nccl': 'nccl1.3',
             'requires': [
                 'pip==9.0.1', 'setuptools', 'cython==0.28.3', 'numpy>=1.14',
-                'scipy<0.19', 'sphinx==1.5.3', 'sphinx_rtd_theme',
-            ]
+                'scipy<0.19',
+            ] + SPHINX_REQUIREMENTS
         }
         script = './test_cupy_doc.sh'
 

--- a/run_test.py
+++ b/run_test.py
@@ -14,8 +14,8 @@ import version
 SPHINX_REQUIREMENTS = [
     'Pygments==2.2.0',
     'docutils==0.13.1',
-    #'mock==1.0.1',
-    #'pillow==2.6.1',
+    # 'mock==1.0.1',
+    # 'pillow==2.6.1',
     'alabaster>=0.7,<0.8,!=0.7.5',
     'commonmark==0.5.4',
     'recommonmark==0.4.0',

--- a/run_test.py
+++ b/run_test.py
@@ -8,7 +8,7 @@ import docker
 import version
 
 
-# See sphinx version RTD uses:
+# Simulate the build environment of ReadTheDocs.
 # https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/python_environments.py
 # Some packages are omitted as we have our own requirements.
 SPHINX_REQUIREMENTS = [

--- a/run_test.py
+++ b/run_test.py
@@ -10,11 +10,12 @@ import version
 
 # See sphinx version RTD uses:
 # https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/python_environments.py
+# Some packages are omitted as we have our own requirements.
 SPHINX_REQUIREMENTS = [
     'Pygments==2.2.0',
     'docutils==0.13.1',
-    'mock==1.0.1',
-    'pillow==2.6.1',
+    #'mock==1.0.1',
+    #'pillow==2.6.1',
     'alabaster>=0.7,<0.8,!=0.7.5',
     'commonmark==0.5.4',
     'recommonmark==0.4.0',


### PR DESCRIPTION
It seems RTD now uses the latest Sphinx.

https://github.com/rtfd/readthedocs.org/blob/2.5.3/readthedocs/doc_builder/python_environments.py#L218-L250

Log:
https://readthedocs.org/projects/chainer/builds/7474859/ (click "View raw")

> python /home/docs/checkouts/readthedocs.org/user_builds/chainer/envs/latest/bin/pip install --upgrade --cache-dir /home/docs/checkouts/readthedocs.org/user_builds/chainer/.cache/pip Pygments==2.2.0 setuptools<41 docutils==0.13.1 mock==1.0.1 pillow==2.6.1 alabaster>=0.7,<0.8,!=0.7.5 commonmark==0.5.4 recommonmark==0.4.0 sphinx<2 sphinx-rtd-theme<0.5 readthedocs-sphinx-ext<0.6