### PR TITLE
Add test with pre-release versions

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -16,6 +16,7 @@ _base_choices = [
     ('ubuntu14_py36-pyenv', '3.6.5'),
     ('ubuntu16_py27', '2.7.12'),
     ('ubuntu16_py35', '3.5.2'),
+    ('ubuntu16_py36-pyenv', '3.6.6'),
     ('centos6_py27-pyenv', '2.7.14'),
     ('centos7_py27', '2.7.5'),
     ('centos7_py34-pyenv', '3.4.8')]
@@ -185,14 +186,14 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 '''
 
-ubuntu14_pyenv_base = '''FROM ubuntu:14.04
+ubuntu_pyenv_base = '''FROM ubuntu:{ubuntu_ver}
 
 ENV PATH /usr/lib/ccache:$PATH
 
 RUN apt-get -y update && \\
     apt-get -y upgrade && \\
     apt-get -y install curl g++ gfortran git libhdf5-dev autoconf xz-utils && \\
-    apt-get -y install libbz2-dev libreadline-dev libssl-dev make && \\
+    apt-get -y install libbz2-dev libreadline-dev libffi-dev libssl-dev make && \\
     apt-get clean
 
 RUN git clone git://github.com/yyuu/pyenv.git /opt/pyenv
@@ -206,10 +207,21 @@ RUN pyenv global {python_ver}
 RUN pyenv rehash
 '''
 
-codes['ubuntu14_py35-pyenv'] = ubuntu14_pyenv_base.format(python_ver='.'.join(
-    [str(x) for x in get_python_version('ubuntu14_py35-pyenv')]))
-codes['ubuntu14_py36-pyenv'] = ubuntu14_pyenv_base.format(python_ver='.'.join(
-    [str(x) for x in get_python_version('ubuntu14_py36-pyenv')]))
+codes['ubuntu14_py35-pyenv'] = ubuntu_pyenv_base.format(
+    ubuntu_ver='14.04',
+    python_ver='.'.join(
+        [str(x) for x in get_python_version('ubuntu14_py35-pyenv')]),
+)
+codes['ubuntu14_py36-pyenv'] = ubuntu_pyenv_base.format(
+    ubuntu_ver='14.04',
+    python_ver='.'.join(
+        [str(x) for x in get_python_version('ubuntu14_py36-pyenv')]),
+)
+codes['ubuntu16_py36-pyenv'] = ubuntu_pyenv_base.format(
+    ubuntu_ver='16.04',
+    python_ver='.'.join(
+        [str(x) for x in get_python_version('ubuntu16_py36-pyenv')]),
+)
 
 codes['ubuntu16_py27'] = '''FROM ubuntu:16.04
 

--- a/run_test.py
+++ b/run_test.py
@@ -103,12 +103,14 @@ if __name__ == '__main__':
             'cudnn': 'cudnn71-cuda92',
             'nccl': 'nccl2.2-cuda92',
             'requires': [
-                # Use '>=0a0' to install the latest pre-release version
+                # Use '>=0.0.dev0' to install the latest pre-release version
                 # available on PyPI.
+                # https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions
                 # TODO(kmaehashi) rewrite iDeep constraints after v2.0 support
-                'setuptools>=0a0', 'cython>=0a0', 'numpy>=0a0',
-                'scipy<0.19', 'h5py>=0a0', 'theano>=0a0', 'protobuf>=0a0',
-                'ideep4py>=0a0, <1.1',
+                'setuptools>=0.0.dev0', 'cython>=0.0.dev0', 'numpy>=0.0.dev0',
+                'scipy<0.19', 'h5py>=0.0.dev0', 'theano>=0.0.dev0',
+                'protobuf>=0.0.dev0',
+                'ideep4py>=0.0.dev0, <1.1',
             ],
         }
         if args.test == 'chainer-head':

--- a/run_test.py
+++ b/run_test.py
@@ -33,6 +33,7 @@ if __name__ == '__main__':
         'chainer-head',
         'cupy-py2', 'cupy-py3', 'cupy-py35', 'cupy-slow',
         'cupy-example', 'cupy-doc',
+        'cupy-head',
     ], required=True)
     parser.add_argument('--no-cache', action='store_true')
     parser.add_argument('--timeout', default='2h')
@@ -95,7 +96,7 @@ if __name__ == '__main__':
         }
         script = './test.sh'
 
-    elif args.test == 'chainer-head':
+    elif args.test == 'chainer-head' or args.test == 'cupy-head':
         conf = {
             'base': 'ubuntu16_py36-pyenv',
             'cuda': 'cuda92',
@@ -110,7 +111,12 @@ if __name__ == '__main__':
                 'ideep4py>=0a0, <1.1',
             ],
         }
-        script = './test.sh'
+        if args.test == 'chainer-head':
+            script = './test.sh'
+        elif args.test == 'cupy-head':
+            script = './test_cupy.sh'
+        else:
+            assert False  # should not reach
 
     elif args.test == 'chainer-slow':
         conf = {

--- a/run_test.py
+++ b/run_test.py
@@ -30,6 +30,7 @@ if __name__ == '__main__':
     parser.add_argument('--test', choices=[
         'chainer-py2', 'chainer-py3', 'chainer-py35', 'chainer-slow',
         'chainer-example', 'chainer-prev_example', 'chainer-doc',
+        'chainer-head',
         'cupy-py2', 'cupy-py3', 'cupy-py35', 'cupy-slow',
         'cupy-example', 'cupy-doc',
     ], required=True)
@@ -90,6 +91,23 @@ if __name__ == '__main__':
                 'setuptools', 'cython==0.28.3', 'numpy<1.15',
                 'scipy<0.19', 'h5py', 'theano', 'protobuf<3',
                 'ideep4py<1.1',
+            ],
+        }
+        script = './test.sh'
+
+    elif args.test == 'chainer-head':
+        conf = {
+            'base': 'ubuntu16_py36-pyenv',
+            'cuda': 'cuda92',
+            'cudnn': 'cudnn71-cuda92',
+            'nccl': 'nccl2.2-cuda92',
+            'requires': [
+                # Use '>=0a0' to install the latest pre-release version
+                # available on PyPI.
+                # TODO(kmaehashi) rewrite iDeep constraints after v2.0 support
+                'setuptools>=0a0', 'cython>=0a0', 'numpy>=0a0',
+                'scipy<0.19', 'h5py>=0a0', 'theano>=0a0', 'protobuf>=0a0',
+                'ideep4py>=0a0, <1.1',
             ],
         }
         script = './test.sh'


### PR DESCRIPTION
This implements #166.

This mainly intends to test with RC version of `numpy`.
(Note that some packages do not use PyPI for distributing pre-release versions.)

I initially thought that we should build from master branch of each product, but I think it's too aggressive and costly, as such tests is likely to break easily and we have to identify if the error is caused by our code or not every time the test runs.