### PR TITLE
Only run tests under `tests/chainer_tests`

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,7 @@ fi
 
 pytest_opts+=(-m "${pytest_marks[*]}")
 
-python -m pytest "${pytest_opts[@]}" tests
+python -m pytest "${pytest_opts[@]}" tests/chainer_tests
 
 # Submit coverage to Coveralls
 python ../push_coveralls.py

--- a/test_slow.sh
+++ b/test_slow.sh
@@ -37,4 +37,4 @@ fi
 
 pytest_opts+=(-m "${pytest_marks[*]}")
 
-python -m pytest "${pytest_opts[@]}" tests
+python -m pytest "${pytest_opts[@]}" tests/chainer_tests


### PR DESCRIPTION
This is to make Chainer ready to merge ChainerMN.
ChainerMN tests will reside in `tests/chainermn_tests`, which will be separately tested in different test infrastructure.