### PR TITLE
Revert "Test with iDeep 2.0"

### DIFF
--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -17,7 +17,7 @@ params = {
     'h5py': [None, '2.5', '2.6', '2.7'],
     'pillow': [None, '3.4', '4.0', '4.1'],
     'theano': [None, '0.8', '0.9'],
-    'ideep': [None, '2.0'],
+    'ideep': [None, '1.0'],
 }
 
 

--- a/run_multi_test.py
+++ b/run_multi_test.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser.add_argument('--cuda', choices=docker.cuda_choices, required=True)
     parser.add_argument('--cudnn', choices=docker.cudnn_choices, required=True)
     parser.add_argument('--nccl', choices=docker.nccl_choices, required=True)
-    parser.add_argument('--ideep', choices=['none', '1.0', '2.0'], required=True)
+    parser.add_argument('--ideep', choices=['none', '1.0'], required=True)
     parser.add_argument('--numpy', choices=['1.9', '1.10', '1.11', '1.12', '1.13', '1.14'],
                         required=True)
     parser.add_argument('--protobuf', choices=['2', '3', 'cpp-3'])
@@ -96,8 +96,6 @@ if __name__ == '__main__':
 
     if args.ideep == '1.0':
         conf['requires'].append('ideep4py<1.1')
-    elif args.ideep == '2.0':
-        conf['requires'].append('ideep4py<2.1')
 
     use_ideep = any(['ideep4py' in req for req in conf['requires']])
 

--- a/run_test.py
+++ b/run_test.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
             'requires': [
                 'setuptools', 'cython==0.28.3', 'numpy<1.15',
                 'scipy<0.19', 'h5py', 'theano', 'protobuf<3',
-                'ideep4py<2.1',
+                'ideep4py<1.1',
             ],
         }
         script = './test.sh'
@@ -130,7 +130,7 @@ if __name__ == '__main__':
                 'setuptools', 'cython==0.28.3', 'numpy<1.15',
                 'scipy<0.19', 'h5py', 'theano', 'protobuf<3',
                 'pillow',
-                'ideep4py<2.1',
+                'ideep4py<1.1',
             ],
         }
         script = './test_slow.sh'

--- a/shuffle.py
+++ b/shuffle.py
@@ -18,7 +18,7 @@ def iter_shuffle(lst):
 def _is_ideep_supported(python_version):
     pyver = python_version
     if pyver[0] == 2:
-        return pyver >= (2, 7, 6)
+        return pyver >= (2, 7, 5)
     assert pyver[0] == 3
     if pyver[:2] < (3, 5):
         return False
@@ -133,7 +133,7 @@ def make_conf(params):
     ideep = params.get('ideep')
     if ideep is not None:
         overwrite_requires_version(
-            conf, 'ideep4py', 'ideep4py<2.1')
+            conf, 'ideep4py', make_require('ideep4py', ideep))
 
     append_require(params, conf, 'pillow')
 


### PR DESCRIPTION
Tentatively revert chainer/chainer-test#434 as examples fails to run in iDeep 2.0 PR (https://github.com/chainer/chainer/pull/4933)