### PR TITLE
Install extra requirements for docs

### DIFF
--- a/test_doc.sh
+++ b/test_doc.sh
@@ -5,9 +5,8 @@ python setup.py -q build -j 4 develop install --user || python setup.py -q devel
 cd ..
 
 cd chainer
-python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
+pip install --user -e .[docs]
 
-pip install -e .[docs]
 python -m pip install matplotlib --user
 
 cd docs

--- a/test_doc.sh
+++ b/test_doc.sh
@@ -7,6 +7,7 @@ cd ..
 cd chainer
 python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
 
+pip install -e .[docs]
 python -m pip install matplotlib --user
 
 cd docs


### PR DESCRIPTION
This PR changes the travis test for documentation to install "docs" requirements in `setup.py`, such as the one [here](https://github.com/chainer/chainer/blob/f1e9624fe2dc3810956334f067c9eaa019f7a6f7/setup.py#L54
) for https://github.com/chainer/chainer/pull/5434.

Since the build process of readthedocs can use `exra_require={'docs': ...}` to install dependencies, I think it is convenient to use this feature for travis test as well.
ref: https://docs.readthedocs.io/en/latest/yaml-config.html#python-extra-requirements
