### PR TITLE
Use newer version of protobuf/numpy for Python 3.7 test

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -82,7 +82,6 @@ if __name__ == '__main__':
             'cuda': 'cuda80',
             'cudnn': 'cudnn51-cuda8',
             'nccl': 'nccl1.3',
-            'protobuf-cpp': 'protobuf-cpp-3',
             'requires': [
                 'setuptools', 'pip', 'cython==0.28.3', 'numpy<1.12',
                 'pillow',
@@ -198,7 +197,6 @@ if __name__ == '__main__':
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3',
-            'protobuf-cpp': 'protobuf-cpp-3',
             'requires': [
                 'setuptools', 'pip', 'cython==0.28.0', 'numpy<1.12',
             ],

--- a/run_test.py
+++ b/run_test.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
             'cudnn': 'cudnn51-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'setuptools', 'pip', 'cython==0.28.3', 'numpy<1.12',
+                'setuptools', 'pip', 'cython==0.28.3', 'numpy<1.16',
                 'pillow',
             ],
         }
@@ -96,7 +96,7 @@ if __name__ == '__main__':
             'cudnn': 'cudnn72-cuda92',
             'nccl': 'nccl2.2-cuda92',
             'requires': [
-                'setuptools', 'cython==0.28.3', 'numpy<1.16',
+                'setuptools', 'cython==0.28.3', 'numpy<1.14',
                 'scipy<1.1', 'h5py', 'theano', 'protobuf<3',
                 'ideep4py{}'.format(ideep_req),
             ],
@@ -198,7 +198,7 @@ if __name__ == '__main__':
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'setuptools', 'pip', 'cython==0.28.0', 'numpy<1.12',
+                'setuptools', 'pip', 'cython==0.28.0', 'numpy<1.16',
             ],
         }
         script = './test_cupy.sh'


### PR DESCRIPTION
* protobuf 3.3.0 cannot be built against Python 3.7. As `protobuf` now provides wheel package, which is using C++ implementation, it is not much meaningful to test with protobuf built from source.
* NumPy 1.14.4 is the first version that supports Python 3.7.
  https://github.com/numpy/numpy/blob/master/doc/release/1.14.4-notes.rst