### PR TITLE
Drop support for CUDA 7.0 / 7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is test scripts of chainer and dockerfiles for its test environment.
 Run test scripts with options that specify the environment to test.
 
 ```
-$ ./run_multi_test.py --base=ubuntu14_py2 --numpy=1.9 --cuda=cuda70 --cudnn=cudnn4 --type=gpu
+$ ./run_multi_test.py --base=ubuntu14_py2 --numpy=1.9 --cuda=cuda80 --cudnn=cudnn5-cuda8 --type=gpu
 ```
 
 These test scripts create `Dockerfile`, make containers, and run appropriate test scripts.

--- a/docker.py
+++ b/docker.py
@@ -23,20 +23,21 @@ _base_choices = [
     ('centos7_py34-pyenv', '3.4.8')]
 
 base_choices = [a[0] for a in _base_choices]
-cuda_choices = ['none', 'cuda70', 'cuda75', 'cuda80', 'cuda90', 'cuda91', 'cuda92']
+cuda_choices = ['none', 'cuda80', 'cuda90', 'cuda91', 'cuda92']
 cudnn_choices = [
-    'none', 'cudnn4', 'cudnn5', 'cudnn5-cuda8', 'cudnn51',
-    'cudnn51-cuda8', 'cudnn6', 'cudnn6-cuda8', 'cudnn7-cuda8', 'cudnn7-cuda9',
-    'cudnn7-cuda91', 'cudnn71-cuda8', 'cudnn71-cuda9', 'cudnn71-cuda91',
-    'cudnn71-cuda92', 'cudnn72-cuda8', 'cudnn72-cuda9', 'cudnn72-cuda92']
+    'none',
+    'cudnn5-cuda8', 'cudnn51-cuda8',
+    'cudnn6-cuda8',
+    'cudnn7-cuda8', 'cudnn7-cuda9', 'cudnn7-cuda91',
+    'cudnn71-cuda8', 'cudnn71-cuda9', 'cudnn71-cuda91', 'cudnn71-cuda92',
+    'cudnn72-cuda8', 'cudnn72-cuda9', 'cudnn72-cuda92'
+]
 nccl_choices = [
     'none', 'nccl1.3', 'nccl2.0-cuda8', 'nccl2.0-cuda9', 'nccl2.2-cuda9'
     'nccl2.1-cuda91', 'nccl2.2-cuda92',
 ]
 
 cuda_cudnns = {
-    'cuda70': ['cudnn4'],
-    'cuda75': ['cudnn4', 'cudnn5', 'cudnn51', 'cudnn6'],
     'cuda80': ['cudnn5-cuda8', 'cudnn51-cuda8', 'cudnn6-cuda8',
                'cudnn7-cuda8', 'cudnn71-cuda8', 'cudnn72-cuda8'],
     'cuda90': ['cudnn7-cuda9', 'cudnn71-cuda9', 'cudnn72-cuda9'],
@@ -44,8 +45,6 @@ cuda_cudnns = {
     'cuda92': ['cudnn71-cuda92', 'cudnn72-cuda92'],
 }
 cuda_nccls = {
-    'cuda70': ['nccl1.3'],
-    'cuda75': ['nccl1.3'],
     'cuda80': ['nccl1.3', 'nccl2.0-cuda8'],
     # CUDA 9 does not support nccl 1.3
     'cuda90': ['nccl2.0-cuda9', 'nccl2.2-cuda9'],
@@ -287,15 +286,6 @@ ENV NVCC="ccache nvcc"
 
 # cuda
 
-cuda70_run = 'cuda_7.0.28_linux.run'
-cuda70_url = 'http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers'
-cuda70_installer = 'cuda-linux64-rel-7.0.28-19326674.run'
-
-cuda75_run = 'cuda_7.5.18_linux.run'
-cuda75_url = 'http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers'
-cuda75_driver = 'NVIDIA-Linux-x86_64-352.39.run'
-cuda75_installer = 'cuda-linux64-rel-7.5.18-19867135.run'
-
 cuda80_run = 'cuda_8.0.44_linux-run'
 cuda80_url = 'https://developer.nvidia.com/compute/cuda/8.0/prod/local_installers'
 cuda80_driver = 'NVIDIA-Linux-x86_64-367.48.run'
@@ -342,22 +332,6 @@ LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="{cuda_ver}"
 '''
 
-codes['cuda70'] = cuda_base.format(
-    cuda_ver='7.0',
-    cuda_run=cuda70_run,
-    cuda_url=cuda70_url,
-    installer=cuda70_installer,
-    sha256sum='d1292e9c2bbaddad24c46e0b0d15a7130831bfac0382f7159321f41ae385a5ce',
-)
-
-codes['cuda75'] = cuda_base.format(
-    cuda_ver='7.5',
-    cuda_run=cuda75_run,
-    cuda_url=cuda75_url,
-    installer=cuda75_installer,
-    sha256sum='08411d536741075131a1858a68615b8b73c51988e616e83b835e4632eea75eec',
-)
-
 codes['cuda80'] = cuda_base.format(
     cuda_ver='8.0',
     cuda_run=cuda80_run,
@@ -402,40 +376,16 @@ RUN curl -s -o {cudnn}.tgz http://developer.download.nvidia.com/compute/redist/c
 ENV CUDNN_VER {cudnn_ver}
 '''
 
-codes['cudnn4'] = cudnn_base.format(
-    cudnn='cudnn-7.0-linux-x64-v4.0-prod',
-    cudnn_ver='v4',
-    sha256sum='cd091763d5889f0efff1fbda83bade191f530743a212c6b0ecc2a64d64d94405',
-)
-
-codes['cudnn5'] = cudnn_base.format(
-    cudnn='cudnn-7.5-linux-x64-v5.0-ga',
-    cudnn_ver='v5',
-    sha256sum='c4739a00608c3b66a004a74fc8e721848f9112c5cb15f730c1be4964b3a23b3a',
-)
-
 codes['cudnn5-cuda8'] = cudnn_base.format(
     cudnn='cudnn-8.0-linux-x64-v5.0-ga',
     cudnn_ver='v5',
     sha256sum='af80eb1ce0cb51e6a734b2bdc599e6d50b676eab3921e5bddfe5443485df86b6',
 )
 
-codes['cudnn51'] = cudnn_base.format(
-    cudnn='cudnn-7.5-linux-x64-v5.1',
-    cudnn_ver='v5.1',
-    sha256sum='69ca71f7728b54b6e003393083f419b24774fecd3b08bbf41bceac9a9fe16345',
-)
-
 codes['cudnn51-cuda8'] = cudnn_base.format(
     cudnn='cudnn-8.0-linux-x64-v5.1',
     cudnn_ver='v5.1',
     sha256sum='c10719b36f2dd6e9ddc63e3189affaa1a94d7d027e63b71c3f64d449ab0645ce',
-)
-
-codes['cudnn6'] = cudnn_base.format(
-    cudnn='cudnn-7.5-linux-x64-v6.0',
-    cudnn_ver='v6.0',
-    sha256sum='568d4b070c5f91ab8a15b287b73dd072b99c7267a43edad13f70337cd186c82c',
 )
 
 codes['cudnn6-cuda8'] = cudnn_base.format(

--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -34,8 +34,8 @@ if __name__ == '__main__':
     # cuda, cudnn and numpy is required to make a sdist file.
     build_conf = {
         'base': 'ubuntu14_py27',
-        'cuda': 'cuda70',
-        'cudnn': 'cudnn4',
+        'cuda': 'cuda80',
+        'cudnn': 'cudnn5-cuda8',
         'nccl': 'none',
         'requires': ['cython==0.28.3', 'numpy==1.9.3'],
     }

--- a/run_test.py
+++ b/run_test.py
@@ -65,9 +65,9 @@ if __name__ == '__main__':
     if args.test == 'chainer-py2':
         conf = {
             'base': 'ubuntu14_py27',
-            'cuda': 'cuda70',
-            'cudnn': 'cudnn4',
-            'nccl': 'none',
+            'cuda': 'cuda80',
+            'cudnn': 'cudnn5-cuda8',
+            'nccl': 'nccl1.3',
             'requires': [
                 'setuptools', 'pip', 'cython==0.28.0', 'numpy<1.10',
                 'scipy<0.19', 'h5py', 'theano', 'pillow',
@@ -79,9 +79,9 @@ if __name__ == '__main__':
     elif args.test == 'chainer-py3':
         conf = {
             'base': 'ubuntu16_py37-pyenv',
-            'cuda': 'cuda80',
-            'cudnn': 'cudnn51-cuda8',
-            'nccl': 'nccl1.3',
+            'cuda': 'cuda90',
+            'cudnn': 'cudnn72-cuda9',
+            'nccl': 'nccl2.0-cuda9',
             'requires': [
                 'setuptools', 'pip', 'cython==0.28.3', 'numpy<1.16',
                 'pillow',
@@ -93,7 +93,7 @@ if __name__ == '__main__':
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda92',
-            'cudnn': 'cudnn72-cuda92',
+            'cudnn': 'cudnn71-cuda92',
             'nccl': 'nccl2.2-cuda92',
             'requires': [
                 'setuptools', 'cython==0.28.3', 'numpy<1.14',
@@ -107,7 +107,7 @@ if __name__ == '__main__':
         conf = {
             'base': 'ubuntu16_py36-pyenv',
             'cuda': 'cuda92',
-            'cudnn': 'cudnn71-cuda92',
+            'cudnn': 'cudnn72-cuda92',
             'nccl': 'nccl2.2-cuda92',
             'requires': [
                 # Use '>=0.0.dev0' to install the latest pre-release version
@@ -145,9 +145,9 @@ if __name__ == '__main__':
     elif args.test == 'chainer-example':
         conf = {
             'base': 'centos7_py27',
-            'cuda': 'cuda75',
+            'cuda': 'cuda90',
             'cudnn': 'cudnn71-cuda9',
-            'nccl': 'nccl1.3',
+            'nccl': 'nccl2.2-cuda9',
             'requires': ['setuptools', 'cython==0.28.3', 'numpy<1.13'],
         }
         script = './test_example.sh'
@@ -155,8 +155,8 @@ if __name__ == '__main__':
     elif args.test == 'chainer-prev_example':
         conf = {
             'base': 'ubuntu14_py27',
-            'cuda': 'cuda90',
-            'cudnn': 'cudnn7-cuda9',
+            'cuda': 'cuda92',
+            'cudnn': 'cudnn72-cuda92',
             'nccl': 'none',
             'requires': ['setuptools', 'pip', 'cython==0.28.3', 'numpy<1.12'],
         }
@@ -181,8 +181,8 @@ if __name__ == '__main__':
     elif args.test == 'cupy-py2':
         conf = {
             'base': 'ubuntu14_py27',
-            'cuda': 'cuda70',
-            'cudnn': 'cudnn4',
+            'cuda': 'cuda80',
+            'cudnn': 'cudnn51-cuda8',
             'nccl': 'none',
             'requires': [
                 'setuptools', 'pip', 'cython==0.28.3', 'numpy<1.16',
@@ -194,9 +194,9 @@ if __name__ == '__main__':
     elif args.test == 'cupy-py3':
         conf = {
             'base': 'ubuntu16_py37-pyenv',
-            'cuda': 'cuda80',
-            'cudnn': 'cudnn6-cuda8',
-            'nccl': 'nccl1.3',
+            'cuda': 'cuda90',
+            'cudnn': 'cudnn7-cuda9',
+            'nccl': 'nccl2.0-cuda9',
             'requires': [
                 'setuptools', 'pip', 'cython==0.28.0', 'numpy<1.16',
             ],
@@ -230,8 +230,8 @@ if __name__ == '__main__':
     elif args.test == 'cupy-example':
         conf = {
             'base': 'centos7_py27',
-            'cuda': 'cuda75',
-            'cudnn': 'cudnn5',
+            'cuda': 'cuda80',
+            'cudnn': 'cudnn5-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
                 'setuptools', 'cython==0.28.3', 'numpy<1.13', 'scipy<0.19',


### PR DESCRIPTION
* Remove `cuda70` and `cuda75`
* Remove `cudnn4`, `cudnn5`, `cudnn51`, `cudnn6` (for CUDA 7.x)
  (note that cuDNN v5+ with CUDA 8.x is still supported e.g., `cudnn5-cuda8`).