### PR TITLE
Use same compiler for python binding installation of protobuf

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -623,7 +623,7 @@ RUN tmpdir=`mktemp -d` && \\
     curl -sL -o protobuf-python-{protobuf}.tar.gz https://github.com/google/protobuf/releases/download/v{protobuf}/protobuf-python-{protobuf}.tar.gz && \\
     tar -xzf protobuf-python-{protobuf}.tar.gz && \\
     cd protobuf-{protobuf} && CC=/usr/bin/gcc CXX=/usr/bin/g++ ./configure && make -j4 install && ldconfig && \\
-    cd python && python setup.py install --cpp_implementation && \\
+    cd python && CC=/usr/bin/gcc CXX=/usr/bin/g++ python setup.py install --cpp_implementation && \\
     cd /tmp && rm -rf $tmpdir
 WORKDIR /tmp
 '''


### PR DESCRIPTION
This fixes the following error:

```
tests/chainer_tests/exporters_tests/test_caffe.py:7: in <module>
    from chainer.exporters import caffe
chainer/exporters/__init__.py:1: in <module>
    from chainer.exporters import caffe  # NOQA
chainer/exporters/caffe.py:11: in <module>
    from chainer.links.caffe.protobuf3 import caffe_pb2 as caffe_pb
chainer/links/caffe/__init__.py:1: in <module>
    from chainer.links.caffe.caffe_function import CaffeFunction  # NOQA
chainer/links/caffe/caffe_function.py:10: in <module>
    from chainer.links.caffe.protobuf3 import caffe_pb2 as caffe_pb
chainer/links/caffe/protobuf3/caffe_pb2.py:7: in <module>
    from google.protobuf import descriptor as _descriptor
/opt/pyenv/versions/3.6.6/lib/python3.6/site-packages/protobuf-3.3.0-py3.6-linux-x86_64.egg/google/protobuf/descriptor.py:46: in <module>
    from google.protobuf.pyext import _message
E   ImportError: /opt/pyenv/versions/3.6.6/lib/python3.6/site-packages/protobuf-3.3.0-py3.6-linux-x86_64.egg/google/protobuf/pyext/_message.cpython-36m-x86_64-linux-gnu.so: undefined symbol: _ZNK6google8protobuf10TextFormat17FieldValuePrinter9PrintBoolEb
```