### PR TITLE
Specify `SPHINXOPTS` env

### DIFF
--- a/test_cupy_doc.sh
+++ b/test_cupy_doc.sh
@@ -4,6 +4,7 @@ cd cupy
 python setup.py -q build -j 4 develop install --user || python setup.py -q develop install --user
 
 cd docs
+export SPHINXOPTS=-W
 
 # Generate HTML and preserve it for preview.
 make html

--- a/test_doc.sh
+++ b/test_doc.sh
@@ -10,6 +10,7 @@ pip install --user -e .[docs]
 python -m pip install matplotlib --user
 
 cd docs
+export SPHINXOPTS=-W
 
 # Generate HTML and preserve it for preview.
 make html


### PR DESCRIPTION
It's required by the tests, not by users, that `make html` emits no warning.