### PR TITLE
Avoid using six

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -32,7 +32,7 @@ def get_shuffle_params(params, index):
     random.seed(0)
     keys = sorted(params.keys())
     iters = [iter_shuffle(params[key]) for key in keys]
-    vals = tuple(iter[index] for iter in iters)
+    vals = tuple(next(itertools.islice(iter, index, None)) for iter in iters)
     ret = dict(zip(keys, vals))
 
     # avoid SEGV

--- a/shuffle.py
+++ b/shuffle.py
@@ -2,8 +2,6 @@ import itertools
 import random
 import sys
 
-import six
-
 import docker
 
 
@@ -34,7 +32,7 @@ def get_shuffle_params(params, index):
     random.seed(0)
     keys = sorted(params.keys())
     iters = [iter_shuffle(params[key]) for key in keys]
-    vals = next(itertools.islice(six.moves.zip(*iters), index, None))
+    vals = next(itertools.islice(zip(*iters), index, None))
     ret = dict(zip(keys, vals))
 
     # avoid SEGV

--- a/shuffle.py
+++ b/shuffle.py
@@ -32,7 +32,7 @@ def get_shuffle_params(params, index):
     random.seed(0)
     keys = sorted(params.keys())
     iters = [iter_shuffle(params[key]) for key in keys]
-    vals = next(itertools.islice(zip(*iters), index, None))
+    vals = tuple(iter[index] for iter in iters)
     ret = dict(zip(keys, vals))
 
     # avoid SEGV


### PR DESCRIPTION
I want to avoid testing utilities depending on non-standard module.
This is related to migration of Jenkins server.