### PR TITLE
Use old option `--gpu` to support Chainer v5

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -60,7 +60,7 @@ $run examples/imagenet/train_imagenet.py --test -a alex -R ../data/imagenet -B 1
 $run examples/imagenet/train_imagenet.py --test -a googlenet -R ../data/imagenet -B 1 -b 1 -E 1 $imagenet_data $imagenet_data
 $run examples/imagenet/train_imagenet.py --test -a googlenetbn -R ../data/imagenet -B 1 -b 1 -E 1 $imagenet_data $imagenet_data
 
-$run examples/imagenet/train_imagenet.py --dali --device=0 --test -a nin -R ../data/imagenet -B 1 -b 1 -E 1 $imagenet_data $imagenet_data
+$run examples/imagenet/train_imagenet.py --dali --gpu=0 --test -a nin -R ../data/imagenet -B 1 -b 1 -E 1 $imagenet_data $imagenet_data
 
 # word2vec
 echo "Running word2vec example"


### PR DESCRIPTION
Resolve the issue: https://github.com/chainer/chainer-test/pull/495#issuecomment-473778861