### PR TITLE
Remove branches for old version from seq2seq example test

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -90,17 +90,8 @@ $run examples/dcgan/train_dcgan.py -b 1 -e 1 -i ../data/dcgan --n_hidden=10 --sn
 $run examples/dcgan/train_dcgan.py -b 1 -e 1 --gpu=0 -i ../data/dcgan --n_hidden=10 --snapshot_interval 1 --display_interval 1
 
 # seq2seq
-if [ -f examples/seq2seq/seq2seq.py ]; then
-  # TODO: seq2seq example in v3 branch does not support --validation-interval option.
-  # Remove this code after when we stop maintaining v3 branch.
-  VALIDATION_OPTS=""
-  if grep validation-interval examples/seq2seq/seq2seq.py; then
-    VALIDATION_OPTS="--validation-interval 1"
-  fi
-
-  $run examples/seq2seq/seq2seq.py ../data/seq2seq/source.txt ../data/seq2seq/target.txt ../data/seq2seq/source.vocab.txt ../data/seq2seq/target.vocab.txt --unit 8  --validation-source ../data/seq2seq/source.txt --validation-target ../data/seq2seq/target.txt ${VALIDATION_OPTS}
-  $run examples/seq2seq/seq2seq.py ../data/seq2seq/source.txt ../data/seq2seq/target.txt ../data/seq2seq/source.vocab.txt ../data/seq2seq/target.vocab.txt --unit 8  --validation-source ../data/seq2seq/source.txt --validation-target ../data/seq2seq/target.txt ${VALIDATION_OPTS} --gpu=0
-fi
+$run examples/seq2seq/seq2seq.py ../data/seq2seq/source.txt ../data/seq2seq/target.txt ../data/seq2seq/source.vocab.txt ../data/seq2seq/target.vocab.txt --unit 8  --validation-source ../data/seq2seq/source.txt --validation-target ../data/seq2seq/target.txt --validation-interval 1
+$run examples/seq2seq/seq2seq.py ../data/seq2seq/source.txt ../data/seq2seq/target.txt ../data/seq2seq/source.vocab.txt ../data/seq2seq/target.vocab.txt --unit 8  --validation-source ../data/seq2seq/source.txt --validation-target ../data/seq2seq/target.txt --validation-interval 1 --gpu=0
 
 # text classification
 echo "Text classification example"


### PR DESCRIPTION
This PR removes the branches for the obsolete Chainer v3 from the test of the seq2seq example.