### PR TITLE
Fix cupy-py3 error

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -354,6 +354,7 @@ RUN curl -sL -o {cuda_run} {cuda_url}/{cuda_run} && \\
     echo "{sha256sum}  {cuda_run}" | sha256sum -cw --quiet - && \\
     chmod +x {cuda_run} && sync && \\
     ./{cuda_run} --silent --toolkit && \\
+    ls -al /usr/local/cuda && \\
     cd / && \\
     rm -rf /opt/nvidia
 

--- a/run_test.py
+++ b/run_test.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
 
     elif args.test == 'cupy-py3':
         conf = {
-            'base': 'ubuntu18_py37-pyenv',
+            'base': 'ubuntu16_py37-pyenv',
             'cuda': 'cuda90',
             'cudnn': 'cudnn7-cuda9',
             'nccl': 'nccl2.0-cuda9',


### PR DESCRIPTION
Follow-up for #524; Ubuntu 18 is not supported by CUDA 9.
https://docs.nvidia.com/cuda/archive/9.2/cuda-installation-guide-linux/index.html#system-requirements

CUDA installer checks if the version of host compiler is compatible with the CUDA version. However it exits with status 0 without installing CUDA if the compatibility check fails.