### PR TITLE
Enable CuPy test without checking out Chainer

### DIFF
--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -8,6 +8,10 @@ import shuffle
 import version
 
 
+ideep_min_version = version.get_ideep_version_from_chainer_docs()
+assert ideep_min_version is not None
+
+
 params = {
     'base': docker.base_choices,
     'cuda_cudnn_nccl': docker.get_cuda_cudnn_nccl_choices('chainer'),
@@ -19,7 +23,7 @@ params = {
     'theano': [None, '0.8', '0.9', '1.0'],
     'ideep': [
         None,
-        version.get_ideep_version_from_chainer_docs()[:3],  # 'major.minor'
+        ideep_min_version[:3],  # 'major.minor'
     ],
 }
 

--- a/run_test.py
+++ b/run_test.py
@@ -69,7 +69,9 @@ if __name__ == '__main__':
         version.clone_chainer()
 
     ideep_min_version = version.get_ideep_version_from_chainer_docs()
-    if ideep_min_version.startswith('1.'):
+    if ideep_min_version is None:
+        ideep_req = None  # could not determine
+    elif ideep_min_version.startswith('1.'):
         ideep_req = '<1.1'
     elif ideep_min_version.startswith('2.'):
         ideep_req = '<2.1'
@@ -105,6 +107,7 @@ if __name__ == '__main__':
         script = './test.sh'
 
     elif args.test == 'chainer-py35':
+        assert ideep_req is not None
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda92',
@@ -119,6 +122,7 @@ if __name__ == '__main__':
         script = './test.sh'
 
     elif args.test == 'chainer-head' or args.test == 'cupy-head':
+        assert ideep_req is not None
         conf = {
             'base': 'ubuntu16_py36-pyenv',
             'cuda': 'cuda101',
@@ -143,6 +147,7 @@ if __name__ == '__main__':
             assert False  # should not reach
 
     elif args.test == 'chainer-slow':
+        assert ideep_req is not None
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',

--- a/version.py
+++ b/version.py
@@ -70,8 +70,12 @@ def get_cupy_version():
 
 
 def get_ideep_version_from_chainer_docs():
+    # Returns None if chainer directory does not exist.
+    chainer_repo = os.path.join(os.path.dirname(__file__), 'chainer')
+    if not os.path.isdir(chainer_repo):
+        return None
     chainer_docs_install_path = os.path.join(
-        os.path.dirname(__file__), 'chainer/docs/source/install.rst')
+        chainer_repo, 'docs/source/install.rst')
     with open(chainer_docs_install_path) as f:
         doc = f.read()
     return re.search(r'iDeep.* ({})'.format(version_pattern), doc).group(1)


### PR DESCRIPTION
Currently you need to check out chainer repository even if you only want to run cupy-test.
That's because chainer-test tries to retrieve ideep requirement from chainer repository.
This PR makes it return `None` when there's not chainer directory checked out.