### PR TITLE
Tentatively remove sentiment example test

### DIFF
--- a/test_example.sh
+++ b/test_example.sh
@@ -44,9 +44,10 @@ $run examples/ptb/train_ptb.py --gpu=0 --epoch=1 --unit=10 --test
 # sentiment
 echo "Running sentiment example"
 
-$run examples/sentiment/download.py
-$run examples/sentiment/train_sentiment.py --epoch=1 --batchsize=1 --epocheval=1 --test
-$run examples/sentiment/train_sentiment.py --gpu=0 --epoch=1 --batchsize=1 --epocheval=1 --test
+#TODO(maehashi): Tentatively skip these tests until certificates on https://nlp.stanford.edu/sentiment/ is fixed.
+#$run examples/sentiment/download.py
+#$run examples/sentiment/train_sentiment.py --epoch=1 --batchsize=1 --epocheval=1 --test
+#$run examples/sentiment/train_sentiment.py --gpu=0 --epoch=1 --batchsize=1 --epocheval=1 --test
 
 # imagenet
 echo "Runnig imagenet example"

--- a/test_prev_example.sh
+++ b/test_prev_example.sh
@@ -47,9 +47,10 @@ $run examples/ptb/train_ptb.py --gpu=0 --epoch=1 --unit=10 --test
 # sentiment
 echo "Running sentiment example"
 
-$run examples/sentiment/download.py
-$run examples/sentiment/train_sentiment.py --epoch=1 --batchsize=1 --epocheval=1 --test
-$run examples/sentiment/train_sentiment.py --gpu=0 --epoch=1 --batchsize=1 --epocheval=1 --test 
+#TODO(maehashi): Tentatively skip these tests until certificates on https://nlp.stanford.edu/sentiment/ is fixed.
+#$run examples/sentiment/download.py
+#$run examples/sentiment/train_sentiment.py --epoch=1 --batchsize=1 --epocheval=1 --test
+#$run examples/sentiment/train_sentiment.py --gpu=0 --epoch=1 --batchsize=1 --epocheval=1 --test
 
 # imagenet
 echo "Runnig imagenet example"


### PR DESCRIPTION
TLS cert of the server that hosts example dataset expired today. https://nlp.stanford.edu/sentiment/

Tentatively remove the test.
If the situation does not change for a week, let's consider an alternate solution.