### PR TITLE
Use setuptools<42 for Python 3.8

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -107,7 +107,8 @@ def main():
             'cudnn': 'cudnn75-cuda101',
             'nccl': 'nccl2.4-cuda101',
             'requires': [
-                'setuptools', 'pip', 'cython==0.29.13', 'numpy<1.18',
+                # TODO(kmaehashi): Remove setuptools version restrictions
+                'setuptools<42', 'pip', 'cython==0.29.13', 'numpy<1.18',
                 'pillow',
             ],
         }
@@ -232,7 +233,8 @@ def main():
             'cudnn': 'cudnn7-cuda9',
             'nccl': 'nccl2.0-cuda9',
             'requires': [
-                'setuptools', 'pip', 'cython==0.28.0', 'numpy<1.18',
+                # TODO(kmaehashi): Remove setuptools version restrictions
+                'setuptools<42', 'pip', 'cython==0.28.0', 'numpy<1.18',
             ],
         }
         script = './test_cupy.sh'


### PR DESCRIPTION
`setuptools` 42.0.x seems to have an issue with Python 3.8: wheel (cache) build failures are not handled correctly when installing dependency packages. This is an tentative fix to workaround the issue.