### PR TITLE
Update chainer branch

### DIFF
--- a/version.py
+++ b/version.py
@@ -116,9 +116,11 @@ def clone_chainer():
         chainer_branch = 'master'
     else:
         cupy_major, _, _, _ = get_cupy_version()
-        if 4 <= cupy_major:
-            chainer_branch = 'v%d' % cupy_major
-        else:
+        if cupy_major < 4:
             # chainer v(n+1) for cupy v(n)
             chainer_branch = 'v%d' % (cupy_major + 1)
+        elif cupy_major < 7:
+            chainer_branch = 'v%d' % cupy_major
+        else:
+            chainer_branch = 'master'
     git_clone('chainer', 'chainer', chainer_branch)


### PR DESCRIPTION
Fixes branch lookup error:

https://github.com/cupy/cupy/pull/2775
https://jenkins.preferred.jp/job/chainer/job/cupy_pr/716/TEST=cupy-py35,label=mn1-p100/console

```
11:38:18 Cloning into 'chainer'...
11:38:20 warning: Could not find remote branch v7 to clone.
11:38:20 fatal: Remote branch v7 not found in upstream origin
11:38:20 cloning chainer/chainer v7
11:38:20 Traceback (most recent call last):
11:38:20   File "./run_test.py", line 338, in <module>
11:38:20     main()
11:38:20   File "./run_test.py", line 69, in main
11:38:20     version.clone_chainer()
11:38:20   File "/home/jenkins-external-slave/workspace/chainer/cupy_pr@4/TEST/cupy-py35/label/mn1-p100/version.py", line 124, in clone_chainer
11:38:20     git_clone('chainer', 'chainer', chainer_branch)
11:38:20   File "/home/jenkins-external-slave/workspace/chainer/cupy_pr@4/TEST/cupy-py35/label/mn1-p100/version.py", line 96, in git_clone
11:38:20     'git', 'clone', repository, '--depth=1', '-b', branch])
11:38:20   File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
11:38:20     raise CalledProcessError(retcode, cmd)
11:38:20 subprocess.CalledProcessError: Command '['git', 'clone', 'https://github.com/chainer/chainer.git', '--depth=1', '-b', 'v7']' returned non-zero exit status 128
```