### PR TITLE
Apply is_master_branch() workaround to minimum NumPy version

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -73,15 +73,16 @@ def main():
     if args.clone_chainer:
         version.clone_chainer()
 
-    skip_chainer_test = (
-        _get_job_name() == 'cupy_pr' and
-        (version.get_cupy_version() >= (8,) or
-         # is_master_branch() is required because v8 beta branch has v7 as
-         # the version number in _version.py.
-         # After releasing v8 as stable, remove this condition.
-         version.is_master_branch('cupy')))
+    is_cupy_8_or_later = (
+        version.get_cupy_version() >= (8,) or
+        # is_master_branch() is required because v8 beta branch has v7 as
+        # the version number in _version.py.
+        # After releasing v8 as stable, remove this condition.
+        version.is_master_branch('cupy'))
 
-    if version.get_cupy_version() < (8,):
+    skip_chainer_test = _get_job_name() == 'cupy_pr' and is_cupy_8_or_later
+
+    if not is_cupy_8_or_later:
         numpy_min_version = '1.9'
     else:
         numpy_min_version = '1.15'
@@ -269,7 +270,7 @@ def main():
         use_cub = True
 
     elif args.test == 'cupy-py35':
-        if version.get_cupy_version() < (8,):
+        if not is_cupy_8_or_later:
             numpy_upper_version = '1.10'
         else:
             # CuPy v8 dropped NumPy<1.15
@@ -289,7 +290,7 @@ def main():
         script = './test_cupy.sh'
 
     elif args.test == 'cupy-slow':
-        if version.get_cupy_version() < (8,):
+        if not is_cupy_8_or_later:
             numpy_upper_version = '1.11'
         else:
             # CuPy v8 dropped NumPy<1.15
@@ -309,7 +310,7 @@ def main():
         script = './test_cupy_slow.sh'
 
     elif args.test == 'cupy-example':
-        if version.get_cupy_version() < (8,):
+        if not is_cupy_8_or_later:
             numpy_upper_version = '1.13'
         else:
             # CuPy v8 dropped NumPy<1.15


### PR DESCRIPTION
The same workaround as #556 applied to #553