### PR TITLE
Use newer NumPy version

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -83,8 +83,11 @@ def main():
 
     if version.get_cupy_version() < (8,):
         numpy_min_version = '1.9'
+        numpy_newest_upper_version = '1.18'
     else:
         numpy_min_version = '1.15'
+        numpy_newest_upper_version = '1.19'
+
 
     ideep_min_version = version.get_ideep_version_from_chainer_docs()
     if ideep_min_version is None:
@@ -103,6 +106,8 @@ def main():
             print('Skipping chainer test for CuPy>=8')
             return
 
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu18_py38-pyenv',
             'cuda': 'cuda101',
@@ -112,8 +117,7 @@ def main():
                 # TODO(kmaehashi): Remove setuptools version restrictions
                 # https://github.com/chainer/chainer-test/issues/565
                 'setuptools<42', 'pip', 'cython==0.29.13',
-                'numpy>={},<1.18'.format(numpy_min_version),
-                'pillow',
+                numpy_requires, 'pillow',
             ],
         }
         script = './test.sh'
@@ -124,14 +128,15 @@ def main():
             print('Skipping chainer test for CuPy>=8')
             return
 
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda92',
             'cudnn': 'cudnn71-cuda92',
             'nccl': 'nccl2.2-cuda92',
             'requires': [
-                'setuptools', 'cython==0.29.13',
-                'numpy>={},<1.14'.format(numpy_min_version),
+                'setuptools', 'cython==0.29.13', numpy_requires,
                 'scipy<1.1', 'h5py', 'theano', 'protobuf<3',
                 'ideep4py{}'.format(ideep_req),
             ],
@@ -165,14 +170,16 @@ def main():
 
     elif args.test == 'chainer-slow':
         assert ideep_req is not None
+
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'setuptools', 'cython==0.29.13',
-                'numpy>={},<1.16'.format(numpy_min_version),
+                'setuptools', 'cython==0.29.13', numpy_requires,
                 'scipy<1.1', 'h5py', 'theano', 'protobuf<3',
                 'pillow',
                 'ideep4py{}'.format(ideep_req),
@@ -186,14 +193,15 @@ def main():
             return
 
         base = 'ubuntu16_py35'
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': base,
             'cuda': 'cuda90',
             'cudnn': 'cudnn73-cuda9',
             'nccl': 'nccl2.2-cuda9',
             'requires': [
-                'setuptools', 'cython==0.29.13',
-                'numpy>={},<1.13'.format(numpy_min_version),
+                'setuptools', 'cython==0.29.13', numpy_requires,
             ],
         }
         script = './test_example.sh'
@@ -204,14 +212,15 @@ def main():
             return
 
         base = 'ubuntu16_py35'
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': base,
             'cuda': 'cuda92',
             'cudnn': 'cudnn72-cuda92',
             'nccl': 'none',
             'requires': [
-                'setuptools', 'pip', 'cython==0.29.13',
-                'numpy>={},<1.12'.format(numpy_min_version),
+                'setuptools', 'pip', 'cython==0.29.13', numpy_requires,
             ],
         }
         script = './test_prev_example.sh'
@@ -224,6 +233,8 @@ def main():
         # Note that NumPy 1.14 or later is required to run doctest, as
         # the document uses new textual representation of arrays introduced in
         # NumPy 1.14.
+        numpy_requires = 'numpy>={},<{}'.format(
+            '1.15', numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
@@ -231,13 +242,15 @@ def main():
             'nccl': 'none',
             'requires': [
                 'pip==9.0.1', 'setuptools', 'cython==0.29.13', 'matplotlib',
-                'numpy>=1.15', 'scipy>=1.0', 'theano',
+                numpy_requires, 'scipy>=1.0', 'theano',
             ] + SPHINX_REQUIREMENTS_CONDA
         }
         script = './test_doc.sh'
         build_chainerx = True
 
     elif args.test == 'cupy-py3':
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu18_py38-pyenv',
             'cuda': 'cuda100',
@@ -246,13 +259,14 @@ def main():
             'requires': [
                 # TODO(kmaehashi): Remove setuptools version restrictions
                 # https://github.com/chainer/chainer-test/issues/565
-                'setuptools<42', 'pip', 'cython==0.28.0',
-                'numpy>={},<1.18'.format(numpy_min_version),
+                'setuptools<42', 'pip', 'cython==0.28.0', numpy_requires
             ],
         }
         script = './test_cupy.sh'
 
     elif args.test == 'cupy-py3-cub':
+        numpy_requires = 'numpy>={},<{}'.format(
+            numpy_min_version, numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu18_py38-pyenv',
             'cuda': 'cuda100',
@@ -261,8 +275,7 @@ def main():
             'requires': [
                 # TODO(kmaehashi): Remove setuptools version restrictions
                 # https://github.com/chainer/chainer-test/issues/565
-                'setuptools<42', 'pip', 'cython==0.28.0',
-                'numpy>={},<1.18'.format(numpy_min_version),
+                'setuptools<42', 'pip', 'cython==0.28.0', numpy_requires
             ],
         }
         script = './test_cupy.sh'
@@ -273,7 +286,7 @@ def main():
             numpy_upper_version = '1.10'
         else:
             # CuPy v8 dropped NumPy<1.15
-            numpy_upper_version = '1.16'
+            numpy_upper_version = numpy_newest_upper_version
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_upper_version)
 
@@ -293,7 +306,7 @@ def main():
             numpy_upper_version = '1.11'
         else:
             # CuPy v8 dropped NumPy<1.15
-            numpy_upper_version = '1.16'
+            numpy_upper_version = numpy_newest_upper_version
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_upper_version)
 
@@ -313,7 +326,7 @@ def main():
             numpy_upper_version = '1.13'
         else:
             # CuPy v8 dropped NumPy<1.15
-            numpy_upper_version = '1.16'
+            numpy_upper_version = numpy_newest_upper_version
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_upper_version)
 
@@ -333,13 +346,15 @@ def main():
         # Note that NumPy 1.14 or later is required to run doctest, as
         # the document uses new textual representation of arrays introduced in
         # NumPy 1.14.
+        numpy_requires = 'numpy>={},<{}'.format(
+            '1.15', numpy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'pip==9.0.1', 'setuptools', 'cython==0.29.13', 'numpy>=1.15',
+                'pip==9.0.1', 'setuptools', 'cython==0.29.13', numpy_requires,
                 # scipy 1.4 causes error during installation.
                 'scipy>=1.0,<1.4',
             ] + SPHINX_REQUIREMENTS_PIP

--- a/run_test.py
+++ b/run_test.py
@@ -84,10 +84,13 @@ def main():
     if version.get_cupy_version() < (8,):
         numpy_min_version = '1.9'
         numpy_newest_upper_version = '1.18'
+        scipy_min_version = '0.18'
+        scipy_newest_upper_version = '1.5'
     else:
         numpy_min_version = '1.15'
         numpy_newest_upper_version = '1.19'
-
+        scipy_min_version = '1.1'
+        scipy_newest_upper_version = '1.5'
 
     ideep_min_version = version.get_ideep_version_from_chainer_docs()
     if ideep_min_version is None:
@@ -130,14 +133,17 @@ def main():
 
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_newest_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, scipy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda92',
             'cudnn': 'cudnn71-cuda92',
             'nccl': 'nccl2.2-cuda92',
             'requires': [
-                'setuptools', 'cython==0.29.13', numpy_requires,
-                'scipy<1.1', 'h5py', 'theano', 'protobuf<3',
+                'setuptools', 'cython==0.29.13',
+                numpy_requires, scipy_requires,
+                'h5py', 'theano', 'protobuf<3',
                 'ideep4py{}'.format(ideep_req),
             ],
         }
@@ -173,15 +179,17 @@ def main():
 
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_newest_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, scipy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'setuptools', 'cython==0.29.13', numpy_requires,
-                'scipy<1.1', 'h5py', 'theano', 'protobuf<3',
-                'pillow',
+                'setuptools', 'cython==0.29.13',
+                numpy_requires, scipy_requires,
+                'scipy<1.1', 'h5py', 'theano', 'protobuf<3', 'pillow',
                 'ideep4py{}'.format(ideep_req),
             ],
         }
@@ -235,6 +243,8 @@ def main():
         # NumPy 1.14.
         numpy_requires = 'numpy>={},<{}'.format(
             '1.15', numpy_newest_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, scipy_newest_upper_version)
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
@@ -242,7 +252,7 @@ def main():
             'nccl': 'none',
             'requires': [
                 'pip==9.0.1', 'setuptools', 'cython==0.29.13', 'matplotlib',
-                numpy_requires, 'scipy>=1.0', 'theano',
+                numpy_requires, scipy_requires, 'theano',
             ] + SPHINX_REQUIREMENTS_CONDA
         }
         script = './test_doc.sh'
@@ -282,13 +292,19 @@ def main():
         use_cub = True
 
     elif args.test == 'cupy-py35':
+        # Test for old NumPy/SciPy versions
         if version.get_cupy_version() < (8,):
             numpy_upper_version = '1.10'
+            scipy_upper_version = '0.19'
         else:
             # CuPy v8 dropped NumPy<1.15
-            numpy_upper_version = numpy_newest_upper_version
+            numpy_upper_version = '1.16'
+            scipy_upper_version = '1.2'
+
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, scipy_upper_version)
 
         conf = {
             'base': 'ubuntu16_py35',
@@ -296,19 +312,26 @@ def main():
             'cudnn': 'cudnn76-cuda102',
             'nccl': 'nccl2.5-cuda102',
             'requires': [
-                'setuptools', 'cython==0.29.13', numpy_requires, 'scipy<0.19',
+                'setuptools', 'cython==0.29.13',
+                numpy_requires, scipy_requires,
             ],
         }
         script = './test_cupy.sh'
 
     elif args.test == 'cupy-slow':
+        # Test for old NumPy/SciPy versions
         if version.get_cupy_version() < (8,):
             numpy_upper_version = '1.11'
+            scipy_upper_version = '0.19'
         else:
             # CuPy v8 dropped NumPy<1.15
-            numpy_upper_version = numpy_newest_upper_version
+            numpy_upper_version = '1.16'
+            scipy_upper_version = '1.2'
+
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, scipy_upper_version)
 
         conf = {
             'base': 'ubuntu16_py35',
@@ -316,19 +339,26 @@ def main():
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'none',
             'requires': [
-                'setuptools', 'cython==0.29.13', numpy_requires, 'scipy<0.19',
+                'setuptools', 'cython==0.29.13',
+                numpy_requires, scipy_requires,
             ],
         }
         script = './test_cupy_slow.sh'
 
     elif args.test == 'cupy-example':
+        # Test for old NumPy/SciPy versions
         if version.get_cupy_version() < (8,):
             numpy_upper_version = '1.13'
+            scipy_upper_version = '0.19'
         else:
             # CuPy v8 dropped NumPy<1.15
-            numpy_upper_version = numpy_newest_upper_version
+            numpy_upper_version = '1.16'
+            scipy_upper_version = '1.2'
+
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, scipy_upper_version)
 
         base = 'ubuntu16_py35'
         conf = {
@@ -337,7 +367,8 @@ def main():
             'cudnn': 'cudnn5-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'setuptools', 'cython==0.29.13', numpy_requires, 'scipy<0.19',
+                'setuptools', 'cython==0.29.13',
+                numpy_requires, scipy_requires,
             ],
         }
         script = './test_cupy_example.sh'
@@ -348,15 +379,16 @@ def main():
         # NumPy 1.14.
         numpy_requires = 'numpy>={},<{}'.format(
             '1.15', numpy_newest_upper_version)
+        scipy_requires = 'scipy>={},<{}'.format(
+            scipy_min_version, '1.4')
         conf = {
             'base': 'ubuntu16_py35',
             'cuda': 'cuda80',
             'cudnn': 'cudnn6-cuda8',
             'nccl': 'nccl1.3',
             'requires': [
-                'pip==9.0.1', 'setuptools', 'cython==0.29.13', numpy_requires,
-                # scipy 1.4 causes error during installation.
-                'scipy>=1.0,<1.4',
+                'pip==9.0.1', 'setuptools', 'cython==0.29.13',
+                numpy_requires, scipy_requires,
             ] + SPHINX_REQUIREMENTS_PIP
         }
         script = './test_cupy_doc.sh'


### PR DESCRIPTION
While CuPy v8.0.0a1 Jenkins test, a contradiction occurred in the condition of pip install requirements.

https://jenkins.preferred.jp/job/chainer/job/cupy_pr/995/TEST=chainer-py35,label=mn1-p100/console

16:40:18 Step 26/28 : RUN pip install -U "setuptools" "cython==0.29.13" **"numpy>=1.15,<1.14"** "h5py" "theano" "protobuf<3" "ideep4py<2.1" "attrs<19.2.0" "pytest<4.2" "pytest-timeout" "pytest-cov" "nose" "mock" "coverage<5" "coveralls" "codecov" && rm -rf ~/.cache/pip
