### PR TITLE
Fix numpy versions for install test with master branch

### DIFF
--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -33,6 +33,8 @@ if __name__ == '__main__':
 
     if version.is_master_branch('cupy'):
         params['base'] = docker.base_choices_master
+        params['numpy'] = ['1.15', '1.16', '1.17', '1.18']
+        params['cython'] = ['0.29.13', '0.29.14']
     else:
         params['base'] = docker.base_choices_stable_cupy
 
@@ -50,7 +52,6 @@ if __name__ == '__main__':
     argconfig.parse_args(args, env, build_conf, volume)
     docker.run_with(build_conf, './build_sdist_cupy.sh', volume=volume,
                     env=env)
-
     conf = shuffle.make_shuffle_conf(params, args.id)
     volume = []
     env = {}


### PR DESCRIPTION
There is an error in [Jenkins](https://jenkins.preferred.jp/job/chainer/job/chainer-test_pr/129/label=mn1-p100,test=cupy-install/consoleFull) resulting from having the CuPy master branch requiring a NumPy>=1.15 and the install test setting parameters for an older numpy.
In the end, a new NumPy version is downloaded and an old Cython is used to compile it, causing the error.