### PR TITLE
Install Read the Docs requirements file for cupy-doc test

### DIFF
--- a/test_cupy_doc.sh
+++ b/test_cupy_doc.sh
@@ -4,6 +4,8 @@ pip install --user -e cupy/
 
 cd cupy/docs
 
+pip install --user -r requirements.txt
+
 export SPHINXOPTS=-W
 
 # Generate HTML and preserve it for preview.


### PR DESCRIPTION
Fix #571 .

This PR fixes cupy-doc test to use `cupy/docs/requirements.txt` to control Read the Docs environment in a single file between `chainer-test` and `cupy`.
