### PR TITLE
Change max scipy version for v7

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -85,7 +85,7 @@ def main():
         numpy_min_version = '1.9'
         numpy_newest_upper_version = '1.18'
         scipy_min_version = '0.18'
-        scipy_newest_upper_version = '1.5'
+        scipy_newest_upper_version = '1.2'
     else:
         if args.test.startswith('chainer-'):
             print('Skipping chainer test for CuPy>=8')


### PR DESCRIPTION
scipy 1.5 has issues with several cupy v7 tests as it is pretty new.

scipy 1.2 was released a a bit after cupy v7 and works fine,
Should cupy v7 stick to scipy v1.2 for testing?

With #559 SciPy testing was enabled for the `cupy-py3` CuPy test in Jenkins when it wasn't tested before this is why suddenly errors appeared.
