### PR TITLE
Use DALI for Python 3.5 in chainer-example

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -198,7 +198,7 @@ def main():
         script = './test_slow.sh'
 
     elif args.test == 'chainer-example':
-        base = 'ubuntu16_py35'
+        base = 'ubuntu16_py36-pyenv'
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_newest_upper_version)
         conf = {

--- a/run_test.py
+++ b/run_test.py
@@ -198,7 +198,7 @@ def main():
         script = './test_slow.sh'
 
     elif args.test == 'chainer-example':
-        base = 'ubuntu16_py36-pyenv'
+        base = 'ubuntu16_py35'
         numpy_requires = 'numpy>={},<{}'.format(
             numpy_min_version, numpy_newest_upper_version)
         conf = {

--- a/test_example.sh
+++ b/test_example.sh
@@ -16,7 +16,8 @@ cd ..
 python -m pip install coverage matplotlib nltk progressbar2 --user
 python -m pip install olefile --user
 python -m pip install --global-option="build_ext" --global-option="--disable-jpeg" pillow --user
-python -m pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali --user
+#python -m pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali --user
+python -m pip install 'https://developer.download.nvidia.com/compute/redist/nvidia-dali/nvidia_dali-0.7.0-624544-cp35-cp35m-manylinux1_x86_64.whl' --user
 
 run="coverage run -a --branch"
 


### PR DESCRIPTION
It seems that DALI for Python 3.5 has been removed from NVIDIA PyPI repository
https://developer.download.nvidia.com/compute/redist/nvidia-dali/

This PR directly installs DALI for Python 3.5.