### PR TITLE
Add `get_scipy_choices()`

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -157,6 +157,17 @@ def get_numpy_choices():
     return choices
 
 
+def get_scipy_choices():
+    cupy_version = version.get_cupy_version()
+    if cupy_version[0] < 8:
+        choices = [
+            None, '0.18', '0.19', '1.0', '1.1', '1.2', '1.3', '1.4', '1.5']
+    else:
+        # cupy v8 or later
+        choices = ['1.3', '1.4', '1.5']
+        return choices
+
+
 codes = {}
 
 # base

--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -16,7 +16,7 @@ params = {
     'base': None,
     'cuda_libs': docker.get_cuda_libs_choices('chainer'),
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '0.18', '0.19', '1.0'],
+    'scipy': docker.get_scipy_choices(),
     'protobuf': ['3', 'cpp-3'],
     'h5py': [None, '2.5', '2.6', '2.7', '2.8', '2.9', '2.10'],
     'pillow': [None, '3.4', '4.0', '4.1', '6.2'],

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -14,7 +14,7 @@ params = {
     'base': None,
     'cuda_libs': docker.get_cuda_libs_choices('cupy'),
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '0.19', '1.0'],
+    'scipy': docker.get_scipy_choices(),
 }
 
 


### PR DESCRIPTION
Fix to use `docker.get_scipy_choices()` and exclude old SciPy versions from CuPy v8 tests.