### PR TITLE
Use scipy wheel

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -889,7 +889,6 @@ RUN apt-get remove -y \\
                 dockerfile += 'RUN yum -y update && yum -y install lapack-devel && yum clean all\n'
 
         pillow, requires = partition_requirements('pillow', requires)
-        scipy, requires = partition_requirements('scipy', requires)
 
         if pillow is not None:
             dockerfile += ('RUN pip install -U olefile && '
@@ -900,12 +899,6 @@ RUN apt-get remove -y \\
             dockerfile += (
                 'RUN pip install -U %s && rm -rf ~/.cache/pip\n' %
                 ' '.join(['"%s"' % req for req in requires]))
-
-        if scipy is not None:
-            # SciPy depends on C-API interface of NumPy.
-            # When you install different version of NumPy, it breaks compatibility and causes an error.
-            # So you need to install SciPy from its source to link NumPy you use.
-            dockerfile += 'RUN pip install --no-binary scipy -U "%s" && rm -rf ~/.cache/pip\n' % scipy
 
     # Make a user and home directory to install chainer
     dockerfile += 'RUN useradd -m -u %d user\n' % os.getuid()


### PR DESCRIPTION
This workaround is no longer necessary as we now filter invalid numpy/scipy combinations
https://github.com/chainer/chainer-test/pull/535