### PR TITLE
Use latest Python 3.5

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -10,7 +10,7 @@ import version
 
 
 _base_choices = [
-    ('ubuntu16_py35', '3.5.2'),
+    ('ubuntu16_py35', '3.5.9'),
     ('ubuntu16_py36-pyenv', '3.6.6'),
     ('ubuntu16_py37-pyenv', '3.7.0'),
     ('ubuntu18_py36', '3.6.7'),


### PR DESCRIPTION
For some reason setuptools 50.0.0 released today fails to import matplotlib 3.0.3.

```
17:15:22 + coverage run -a --branch examples/kmeans/kmeans.py -m 1
17:15:23 Traceback (most recent call last):
17:15:23   File "examples/kmeans/kmeans.py", line 6, in <module>
17:15:23     import matplotlib.pyplot as plt
17:15:23   File "/home/user/.local/lib/python3.5/site-packages/matplotlib/__init__.py", line 120, in <module>
17:15:23     import distutils.version
17:15:23   File "<frozen importlib._bootstrap>", line 969, in _find_and_load
17:15:23   File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
17:15:23   File "<frozen importlib._bootstrap>", line 666, in _load_unlocked
17:15:23   File "<frozen importlib._bootstrap>", line 577, in module_from_spec
17:15:23   File "/usr/local/lib/python3.5/dist-packages/_distutils_hack/__init__.py", line 82, in create_module
17:15:23     return importlib.import_module('._distutils', 'setuptools')
17:15:23   File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
17:15:23     return _bootstrap._gcd_import(name[level:], package, level)
17:15:23   File "<frozen importlib._bootstrap>", line 981, in _gcd_import
17:15:23   File "<frozen importlib._bootstrap>", line 931, in _sanity_check
17:15:23 SystemError: Parent module 'setuptools' not loaded, cannot perform relative import
```

Workaround this issue by using Python 3.5.9.