### PR TITLE
temporarily set maxfail and shorten timeout

### DIFF
--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -13,7 +13,8 @@ export CUPY_DUMP_CUDA_SOURCE_ON_ERROR=1
 
 pytest_opts=(
     -rfEX
-    --timeout=300
+    --timeout=30
+    --maxfail=100
     --junit-xml=result.xml
     --cov
     --no-cov-on-fail


### PR DESCRIPTION
Some shuffle tests don't complete due to too many failures.  Example: https://jenkins.preferred.jp/job/chainer/job/daily_master_cupy-shuffled/365/ID=8,label=mn1-p100/console