### PR TITLE
Use Python 3.6 for `cupy_install` test

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -9,6 +9,6 @@ if [ "${USE_GCC6_OR_LATER}" != 0 ]; then
     if which g++-6; then
         # For Ubuntu 16.04 and CentOS 7, use g++-6.
         # For Ubuntu 18.04, uses the default g++-7.
-        export NVCC="${NVCC} --compiler-bindir gcc-6"
+        export NVCC="${NVCC} --compiler-bindir g++-6"
     fi
 fi

--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     # make sdist
     # cuda, cudnn and numpy is required to make a sdist file.
     build_conf = {
-        'base': 'ubuntu18_py36',
+        'base': 'ubuntu16_py36-pyenv',
         'cuda': 'cuda90',
         'cudnn': 'cudnn7-cuda9',
         'nccl': 'none',

--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -41,9 +41,9 @@ if __name__ == '__main__':
     # make sdist
     # cuda, cudnn and numpy is required to make a sdist file.
     build_conf = {
-        'base': 'ubuntu16_py36-pyenv',
-        'cuda': 'cuda90',
-        'cudnn': 'cudnn7-cuda9',
+        'base': 'ubuntu18_py36',
+        'cuda': 'cuda100',
+        'cudnn': 'cudnn75-cuda100',
         'nccl': 'none',
         'cutensor': 'none',
         'requires': ['cython==0.29.13', 'numpy==1.9.3'],

--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     # make sdist
     # cuda, cudnn and numpy is required to make a sdist file.
     build_conf = {
-        'base': 'ubuntu16_py35',
+        'base': 'ubuntu18_py36',
         'cuda': 'cuda90',
         'cudnn': 'cudnn7-cuda9',
         'nccl': 'none',


### PR DESCRIPTION
USes py36-venv in ubuntu 16 because of ubuntu 18 and cuda 9.0 c compiler issues