### PR TITLE
Update cupy-slow conf

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -348,8 +348,8 @@ def main():
 
         conf = {
             'base': 'ubuntu18_py36',
-            'cuda': 'cuda80',
-            'cudnn': 'cudnn6-cuda8',
+            'cuda': 'cuda111',
+            'cudnn': 'cudnn80-cuda111',
             'nccl': 'none',
             'cutensor': 'none',
             'requires': [


### PR DESCRIPTION
`cuda80` has been removed.

https://jenkins.preferred.jp/job/chainer/job/weekly_master_cupy-slow/label=mn1-p100/93/console
```
17:42:44 + ./run_test.py --test cupy-slow --clone-chainer --timeout 3h
17:42:45 Cloning into 'chainer'...
17:42:50 cloning chainer/chainer master
17:42:50 Traceback (most recent call last):
17:42:50   File "./run_test.py", line 459, in <module>
17:42:50     main()
17:42:50   File "./run_test.py", line 455, in main
17:42:50     timeout=args.timeout, gpu_id=args.gpu_id, use_root=args.root)
17:42:50   File "/home/jenkins-external-slave/workspace/chainer/weekly_master_cupy-slow/label/mn1-p100/docker.py", line 894, in run_with
17:42:50     write_dockerfile(conf)
17:42:50   File "/home/jenkins-external-slave/workspace/chainer/weekly_master_cupy-slow/label/mn1-p100/docker.py", line 857, in write_dockerfile
17:42:50     dockerfile = make_dockerfile(conf)
17:42:50   File "/home/jenkins-external-slave/workspace/chainer/weekly_master_cupy-slow/label/mn1-p100/docker.py", line 796, in make_dockerfile
17:42:50     dockerfile += codes[conf['cuda']]
17:42:50 KeyError: 'cuda80'
```

The new values are from `cupy-py36`.