### PR TITLE
Update scipy version

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -180,6 +180,20 @@ def get_numpy_choices():
     return choices
 
 
+def get_scipy_choices():
+    cupy_version = version.get_cupy_version()
+    if cupy_version[0] < 8:
+        choices = [
+            None, '0.18', '0.19', '1.0', '1.1', '1.2', '1.3', '1.4', '1.5']
+    elif cupy_version[0] < 9:
+        # cupy v8
+        choices = [None, '1.3', '1.4', '1.5', '1.6']
+    else:
+        # cupy v9 or later
+        choices = [None, '1.4', '1.5', '1.6']
+        return choices
+
+
 codes = {}
 
 # base

--- a/docker.py
+++ b/docker.py
@@ -191,7 +191,7 @@ def get_scipy_choices():
     else:
         # cupy v9 or later
         choices = [None, '1.4', '1.5', '1.6']
-        return choices
+    return choices
 
 
 codes = {}

--- a/run_combination_test.py
+++ b/run_combination_test.py
@@ -16,7 +16,7 @@ params = {
     'base': None,
     'cuda_libs': docker.get_cuda_libs_choices('chainer'),
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '0.18', '0.19', '1.0'],
+    'scipy': docker.get_scipy_choices(),
     'protobuf': ['3', 'cpp-3'],
     'h5py': [None, '2.5', '2.6', '2.7', '2.8', '2.9', '2.10'],
     'pillow': [None, '3.4', '4.0', '4.1', '6.2'],

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -14,7 +14,7 @@ params = {
     'base': None,
     'cuda_libs': docker.get_cuda_libs_choices('cupy'),
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '1.3', '1.4', '1.5'],
+    'scipy': [None, '1.4', '1.5', '1.6'],
 }
 
 
@@ -36,6 +36,8 @@ if __name__ == '__main__':
         params['base'] = docker.base_choices_master_cupy
     else:
         params['base'] = docker.base_choices_stable_cupy
+        # cupy v8
+        params['scipy'] += ['1.3']
 
     if args.clone_chainer:
         version.clone_chainer()

--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -14,7 +14,7 @@ params = {
     'base': None,
     'cuda_libs': docker.get_cuda_libs_choices('cupy'),
     'numpy': docker.get_numpy_choices(),
-    'scipy': [None, '1.4', '1.5', '1.6'],
+    'scipy': docker.get_scipy_choices(),
 }
 
 
@@ -36,8 +36,6 @@ if __name__ == '__main__':
         params['base'] = docker.base_choices_master_cupy
     else:
         params['base'] = docker.base_choices_stable_cupy
-        # cupy v8
-        params['scipy'] += ['1.3']
 
     if args.clone_chainer:
         version.clone_chainer()

--- a/shuffle.py
+++ b/shuffle.py
@@ -161,6 +161,13 @@ def _is_shuffle_params_valid(ret):
         if ret.get('theano') in ['0.8', '0.9']:
             return False, 'Theano version does not support this NumPy version'
 
+    if ret.get('scipy', None) == '1.6':
+        # Python 3.7+ and NumPy 1.16.5+
+        if py_ver[:2] < (3, 7):
+            return False, 'SciPy version does not support this Python version'
+        if ret['numpy'] in ['1.9', '1.10', '1.11', '1.12', '1.13', '1.14', '1.15']:
+            return False, 'SciPy version does not support this NumPy version'
+
     if 'centos6' in base and ret.get('protobuf') == 'cpp-3':
         return False, 'protobuf cpp-3 not supported on centos6'
 


### PR DESCRIPTION
- Takeover #600.
- Require SciPy 1.4+ in CuPy v9 tests.
- Add SciPy 1.6.