### PR TITLE
sdist no longer contain cpp

### DIFF
--- a/build_sdist_cupy.sh
+++ b/build_sdist_cupy.sh
@@ -2,4 +2,4 @@
 
 cd cupy
 python setup.py -q sdist --cupy-no-cuda
-tar -t -f dist/*.tar.gz | grep .cpp
+tar -t -f dist/*.tar.gz


### PR DESCRIPTION
CuPy sdist no longer contains cpp, removing test to check cpp existence.