### PR TITLE
Fix all tests to run from `cupy/tests`

### DIFF
--- a/test_cupy.sh
+++ b/test_cupy.sh
@@ -25,12 +25,8 @@ else
   pytest_opts+=(-m 'not slow')
 fi
 
-pushd cupy
-python -m pytest "${pytest_opts[@]}" tests/install_tests
-popd
-
 pushd cupy/tests
-python -m pytest "${pytest_opts[@]}" cupy_tests cupyx_tests example_tests
+python -m pytest "${pytest_opts[@]}" .
 
 # Submit coverage to Coveralls
 python ../../push_coveralls.py

--- a/test_cupy_slow.sh
+++ b/test_cupy_slow.sh
@@ -21,10 +21,6 @@ else
   pytest_opts+=(-m 'slow')
 fi
 
-pushd cupy
-python -m pytest "${pytest_opts[@]}" tests/install_tests
-popd
-
 pushd cupy/tests
-python -m pytest "${pytest_opts[@]}" cupy_tests cupyx_tests example_tests
+python -m pytest "${pytest_opts[@]}" .
 popd


### PR DESCRIPTION
Problems in the current test script:
* `test_cupy_slow.sh`, fails at install_tests because install_tests does not have slow tests. (pytest exits with 5 when no tests run)
* fragile to modification. If we add some other test directory e.g. `tests/cupy_backends_test`, it will slip.

Blocked by cupy/cupy#4969