### PR TITLE
Dump environment variable

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -14,3 +14,5 @@ if [ "${USE_GCC6_OR_LATER}" != 0 ]; then
         export CC="gcc-6"
     fi
 fi
+
+env


### PR DESCRIPTION
To check CUDA_VISIBLE_DEVICES environment variable set for failed tests.

FYI, Jenkins node has eight P100 cards.

```
$ nvidia-smi topo -m
	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	CPU Affinity	NUMA Affinity
GPU0	 X 	PIX	PIX	PIX	PHB	PHB	PHB	PHB	0-7,16-23	0
GPU1	PIX	 X 	PIX	PIX	PHB	PHB	PHB	PHB	0-7,16-23	0
GPU2	PIX	PIX	 X 	PIX	PHB	PHB	PHB	PHB	0-7,16-23	0
GPU3	PIX	PIX	PIX	 X 	PHB	PHB	PHB	PHB	0-7,16-23	0
GPU4	PHB	PHB	PHB	PHB	 X 	PIX	PIX	PIX	0-7,16-23	0
GPU5	PHB	PHB	PHB	PHB	PIX	 X 	PIX	PIX	0-7,16-23	0
GPU6	PHB	PHB	PHB	PHB	PIX	PIX	 X 	PIX	0-7,16-23	0
GPU7	PHB	PHB	PHB	PHB	PIX	PIX	PIX	 X 	0-7,16-23	0

Legend:

  X    = Self
  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing at most a single PCIe bridge
  NV#  = Connection traversing a bonded set of # NVLinks
```