### PR TITLE
Use `--force-rm` in docker build

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -1006,7 +1006,7 @@ def write_dockerfile(conf):
 
 
 def build_image(name, no_cache=False):
-    cmd = ['docker', 'build', '-t', name]
+    cmd = ['docker', 'build', '--force-rm', '-t', name]
     if not sys.stdout.isatty():
         cmd.append('-q')
     if no_cache:


### PR DESCRIPTION
This is needed to automatically remove intermediate container when docker build fails.