### PR TITLE
Update for testing chainer

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -105,7 +105,7 @@ def main():
         conf = {
             'base': 'ubuntu18_py38-pyenv',
             'cuda': 'cuda101',
-            'cudnn': 'cudnn75-cuda101',
+            'cudnn': 'cudnn76-cuda101',
             'nccl': 'nccl2.4-cuda101',
             'cutensor': 'none',
             'cusparselt': 'none',
@@ -144,7 +144,7 @@ def main():
         conf = {
             'base': 'ubuntu16_py36-pyenv',
             'cuda': 'cuda101',
-            'cudnn': 'cudnn75-cuda101',
+            'cudnn': 'cudnn76-cuda101',
             'nccl': 'nccl2.4-cuda101',
             'cutensor': 'none',
             'cusparselt': 'none',

--- a/run_test.py
+++ b/run_test.py
@@ -236,7 +236,7 @@ def main():
                 # TODO(kmaehashi): Remove setuptools version restrictions
                 # https://github.com/pypa/setuptools/issues/2352
                 'pip==9.0.1', 'setuptools<50', 'cython==0.29.22', 'matplotlib',
-                'numpy==1.18.*', 'scipy==1.4.*', 'theano', 'wheel',
+                'numpy==1.18.*', 'scipy==1.4.*', 'theano', 'wheel', 'pytest',
             ] + SPHINX_REQUIREMENTS_CONDA
         }
         script = './test_doc.sh'


### PR DESCRIPTION
* CuPy v9 does not support cuDNN 7.5 or earlier
* pytest required for doctests